### PR TITLE
fix(server): resolve critical linting errors blocking CI

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,12 @@
   "parserOptions": {
     "ecmaVersion": 2022,
     "sourceType": "module",
-    "project": true
+    "project": [
+      "./tsconfig.json",
+      "./packages/core/tsconfig.json",
+      "./packages/server/tsconfig.eslint.json",
+      "./packages/cli/tsconfig.json"
+    ]
   },
   "plugins": ["@typescript-eslint"],
   "extends": [

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -50,7 +50,7 @@ const server = new Server(
 /**
  * List available tools
  */
-server.setRequestHandler(ListToolsRequestSchema, async () => {
+server.setRequestHandler(ListToolsRequestSchema, () => {
   return {
     tools: [
       {
@@ -234,7 +234,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 /**
  * List available resources
  */
-server.setRequestHandler(ListResourcesRequestSchema, async () => {
+server.setRequestHandler(ListResourcesRequestSchema, () => {
   return {
     resources: [
       {
@@ -307,7 +307,7 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
 /**
  * Handle MCPs resource
  */
-async function handleMCPsResource() {
+async function handleMCPsResource(): Promise<object> {
   const registry = await getRegistryOperations();
   const servers = await registry.listServers();
 
@@ -345,7 +345,7 @@ async function handleMCPsResource() {
 /**
  * Handle templates resource
  */
-async function handleTemplatesResource() {
+async function handleTemplatesResource(): Promise<object> {
   const { TemplateSelector } = await import('@context-pods/core');
   const selector = new TemplateSelector(CONFIG.templatesPath);
   const templates = await selector.getAvailableTemplates();
@@ -377,7 +377,7 @@ async function handleTemplatesResource() {
 /**
  * Handle status resource
  */
-async function handleStatusResource() {
+async function handleStatusResource(): Promise<object> {
   const registry = await getRegistryOperations();
   const stats = await registry.getStatistics();
 
@@ -416,7 +416,7 @@ async function handleStatusResource() {
 /**
  * Handle statistics resource
  */
-async function handleStatisticsResource() {
+async function handleStatisticsResource(): Promise<object> {
   const registry = await getRegistryOperations();
   const stats = await registry.getStatistics();
 
@@ -437,7 +437,7 @@ async function handleStatisticsResource() {
 /**
  * Start the server
  */
-async function main() {
+async function main(): Promise<void> {
   try {
     // Initialize registry
     logger.info('Initializing Context-Pods registry...');
@@ -463,12 +463,12 @@ async function main() {
 /**
  * Handle graceful shutdown
  */
-process.on('SIGINT', async () => {
+process.on('SIGINT', () => {
   logger.info('Shutting down Context-Pods server...');
   process.exit(0);
 });
 
-process.on('SIGTERM', async () => {
+process.on('SIGTERM', () => {
   logger.info('Shutting down Context-Pods server...');
   process.exit(0);
 });

--- a/packages/server/src/tools/list-mcps.ts
+++ b/packages/server/src/tools/list-mcps.ts
@@ -8,6 +8,7 @@ import {
   MCPServerStatus,
   type MCPServerFilters,
   type MCPServerMetadata,
+  type RegistryOperations,
 } from '../registry/index.js';
 
 /**
@@ -33,49 +34,49 @@ export class ListMCPsTool extends BaseTool {
   /**
    * Validate list-mcps arguments
    */
-  protected async validateArguments(args: unknown): Promise<string | null> {
+  protected validateArguments(args: unknown): Promise<string | null> {
     const typedArgs = args as ListMCPsArgs;
 
     // Validate optional arguments
     if (typedArgs.filter !== undefined) {
       const error = this.validateStringArgument(typedArgs, 'filter', false);
-      if (error) return error;
+      if (error) return Promise.resolve(error);
     }
 
     if (typedArgs.status !== undefined) {
       const error = this.validateStringArgument(typedArgs, 'status', false);
-      if (error) return error;
+      if (error) return Promise.resolve(error);
 
       // Validate status value
       const validStatuses = Object.values(MCPServerStatus);
       if (!validStatuses.includes(typedArgs.status as MCPServerStatus)) {
-        return `Invalid status. Valid values: ${validStatuses.join(', ')}`;
+        return Promise.resolve(`Invalid status. Valid values: ${validStatuses.join(', ')}`);
       }
     }
 
     if (typedArgs.template !== undefined) {
       const error = this.validateStringArgument(typedArgs, 'template', false);
-      if (error) return error;
+      if (error) return Promise.resolve(error);
     }
 
     if (typedArgs.language !== undefined) {
       const error = this.validateStringArgument(typedArgs, 'language', false);
-      if (error) return error;
+      if (error) return Promise.resolve(error);
     }
 
     if (typedArgs.search !== undefined) {
       const error = this.validateStringArgument(typedArgs, 'search', false);
-      if (error) return error;
+      if (error) return Promise.resolve(error);
     }
 
     if (typedArgs.format !== undefined) {
       const validFormats = ['table', 'json', 'summary'];
       if (!validFormats.includes(typedArgs.format)) {
-        return `Invalid format. Valid values: ${validFormats.join(', ')}`;
+        return Promise.resolve(`Invalid format. Valid values: ${validFormats.join(', ')}`);
       }
     }
 
-    return null;
+    return Promise.resolve(null);
   }
 
   /**
@@ -244,7 +245,7 @@ export class ListMCPsTool extends BaseTool {
   /**
    * Format servers as summary
    */
-  private async formatAsSummary(servers: any[], registry: any): Promise<string> {
+  private async formatAsSummary(servers: MCPServerMetadata[], registry: RegistryOperations): Promise<string> {
     const stats = await registry.getStatistics();
 
     let output = `📊 MCP Servers Summary\n\n`;


### PR DESCRIPTION
## Summary
- Fixed critical TypeScript and ESLint errors in server package that were blocking CI
- Removed unnecessary async keywords from handlers without await statements
- Added missing return type annotations for better type safety
- Fixed RegistryOperations import in list-mcps.ts
- Updated validateArguments method to return Promise<string | null> for proper inheritance
- Fixed ESLint parser configuration to properly include server package files

## Test plan
- [x] Server package compiles without TypeScript errors
- [x] ESLint configuration properly parses server files
- [x] Critical blocking errors have been resolved
- [ ] Remaining 93 linting warnings can be addressed in follow-up PRs

🤖 Generated with [Claude Code](https://claude.ai/code)