### PR TITLE
chore: sync all package versions to 0.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-pods",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "description": "ContextPods - a developer tool that generates functional MCP servers from templates",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/cli",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "TurboRepo-optimized CLI for Context-Pods MCP development suite",
   "type": "module",
   "main": "./dist/cli.js",
@@ -39,7 +39,7 @@
   "author": "Conor Luddy",
   "license": "MIT",
   "dependencies": {
-    "@context-pods/core": "^0.0.2",
+    "@context-pods/core": "^0.1.0",
     "commander": "^11.1.0",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/core",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Core utilities and types for Context-Pods MCP farm",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/server",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Core MCP server for Context-Pods toolkit",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@context-pods/core": "^0.0.2",
+    "@context-pods/core": "^0.1.0",
     "sqlite3": "^5.1.6"
   },
   "devDependencies": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/testing",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Comprehensive testing and validation framework for Context-Pods MCP servers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Synchronizes all package versions across the monorepo to match the released git tag v0.1.0
- Updates internal dependencies to use the new version

## Changes
- ✅ Root package.json: `0.0.1` → `0.1.0`
- ✅ @context-pods/cli: `0.0.2` → `0.1.0`
- ✅ @context-pods/core: `0.0.2` → `0.1.0`
- ✅ @context-pods/server: `0.0.2` → `0.1.0`
- ✅ @context-pods/testing: `0.0.2` → `0.1.0`
- ✅ Internal dependencies updated to `^0.1.0`

## Test plan
- [x] All builds pass
- [x] All tests pass
- [x] ESLint checks pass
- [x] TypeScript type checking passes
- [x] Pre-commit hooks pass

## Context
This aligns the npm package versions with the git tag that was already released, ensuring consistency across the project.

🤖 Generated with [Claude Code](https://claude.ai/code)