### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-pods",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "ContextPods - a developer tool that generates functional MCP servers from templates",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "TurboRepo-optimized CLI for Context-Pods MCP development suite",
   "type": "module",
   "main": "./dist/cli.js",
@@ -39,7 +39,7 @@
   "author": "Conor Luddy",
   "license": "MIT",
   "dependencies": {
-    "@context-pods/core": "^0.1.0",
+    "@context-pods/core": "^0.1.1",
     "commander": "^11.1.0",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/core",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Core utilities and types for Context-Pods MCP farm",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/server",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Core MCP server for Context-Pods toolkit",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@context-pods/core": "^0.1.0",
+    "@context-pods/core": "^0.1.1",
     "sqlite3": "^5.1.6"
   },
   "devDependencies": {

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/testing",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Comprehensive testing and validation framework for Context-Pods MCP servers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Bumps all package versions from 0.1.0 to 0.1.1 in preparation for the next release
- Updates internal dependencies to ^0.1.1

## Changes
- ✅ Root package.json: `0.1.0` → `0.1.1`
- ✅ @context-pods/cli: `0.1.0` → `0.1.1`
- ✅ @context-pods/core: `0.1.0` → `0.1.1`
- ✅ @context-pods/server: `0.1.0` → `0.1.1`
- ✅ @context-pods/testing: `0.1.0` → `0.1.1`
- ✅ Internal dependencies updated to `^0.1.1`

## Test plan
- [x] All builds pass
- [x] All tests pass
- [x] ESLint checks pass
- [x] TypeScript type checking passes
- [x] Pre-commit hooks pass

## Next Steps
After merging this PR:
1. Create a GitHub release with tag `v0.1.1`
2. The automated release workflow will publish to npm

🤖 Generated with [Claude Code](https://claude.ai/code)