### PR TITLE
fix: handle pre-bumped versions in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,10 +52,11 @@ jobs:
       - name: Update package versions
         run: |
           # Update all package versions to match the release tag
-          npm version ${{ steps.version.outputs.version }} --workspaces --no-git-tag-version
+          # The --allow-same-version flag prevents errors if versions are already correct
+          npm version ${{ steps.version.outputs.version }} --workspaces --no-git-tag-version --allow-same-version
 
           # Also update the root package.json
-          npm version ${{ steps.version.outputs.version }} --no-git-tag-version
+          npm version ${{ steps.version.outputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Publish to npm
         env:


### PR DESCRIPTION
## Summary
Fixes the release workflow to handle cases where package versions have already been bumped in a PR before creating a release.

## Problem
The v0.1.1 release failed because:
1. We bumped versions to 0.1.1 in PR #61
2. The release workflow tried to bump them again
3. npm version failed with "Version not changed"

## Solution
Added `--allow-same-version` flag to the `npm version` commands in the release workflow. This flag prevents errors when the version is already at the target version.

## Benefits
This fix allows for both workflows:
1. **Pre-bump workflow**: Bump versions in a PR, then create release
2. **Auto-bump workflow**: Create release directly and let workflow bump versions

## Test plan
- [x] Verified `--allow-same-version` flag works with npm version command
- [x] No other changes to workflow logic

Once merged, you can re-run the v0.1.1 release or create v0.1.2.

🤖 Generated with [Claude Code](https://claude.ai/code)