### PR TITLE
feat: add @context-pods/create package for npx support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-pods",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-pods",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7502,10 +7502,10 @@
     },
     "packages/cli": {
       "name": "@context-pods/cli",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
-        "@context-pods/core": "^0.1.3",
+        "@context-pods/core": "^0.1.4",
         "chalk": "^5.3.0",
         "chokidar": "^3.6.0",
         "commander": "^11.1.0",
@@ -7634,7 +7634,7 @@
     },
     "packages/core": {
       "name": "@context-pods/core",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.0"
@@ -7645,7 +7645,7 @@
     },
     "packages/create": {
       "name": "@context-pods/create",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "bin": {
         "create-context-pods": "bin/create-context-pods.js"
@@ -7656,9 +7656,9 @@
     },
     "packages/server": {
       "name": "@context-pods/server",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
-        "@context-pods/core": "^0.1.3",
+        "@context-pods/core": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "sqlite3": "^5.1.6"
       },
@@ -7675,7 +7675,7 @@
     },
     "packages/testing": {
       "name": "@context-pods/testing",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "license": "MIT",
       "dependencies": {
         "@context-pods/core": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-pods",
-  "version": "0.0.1",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-pods",
-      "version": "0.0.1",
+      "version": "0.1.3",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -115,6 +115,10 @@
     },
     "node_modules/@context-pods/core": {
       "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@context-pods/create": {
+      "resolved": "packages/create",
       "link": true
     },
     "node_modules/@context-pods/server": {
@@ -7498,10 +7502,10 @@
     },
     "packages/cli": {
       "name": "@context-pods/cli",
-      "version": "0.0.1",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
-        "@context-pods/core": "file:../core",
+        "@context-pods/core": "^0.1.3",
         "chalk": "^5.3.0",
         "chokidar": "^3.6.0",
         "commander": "^11.1.0",
@@ -7630,7 +7634,7 @@
     },
     "packages/core": {
       "name": "@context-pods/core",
-      "version": "0.0.1",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.0"
@@ -7639,11 +7643,22 @@
         "@types/node": "^20.14.0"
       }
     },
+    "packages/create": {
+      "name": "@context-pods/create",
+      "version": "0.1.3",
+      "license": "MIT",
+      "bin": {
+        "create-context-pods": "bin/create-context-pods.js"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "packages/server": {
       "name": "@context-pods/server",
-      "version": "0.0.1",
+      "version": "0.1.3",
       "dependencies": {
-        "@context-pods/core": "file:../core",
+        "@context-pods/core": "^0.1.3",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "sqlite3": "^5.1.6"
       },
@@ -7660,7 +7675,7 @@
     },
     "packages/testing": {
       "name": "@context-pods/testing",
-      "version": "0.0.1",
+      "version": "0.1.3",
       "license": "MIT",
       "dependencies": {
         "@context-pods/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-pods",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "ContextPods - a developer tool that generates functional MCP servers from templates",
   "private": true,
   "workspaces": [

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,178 @@
+# @context-pods/cli
+
+Command-line interface for the Context-Pods MCP (Model Context Protocol) development suite.
+
+[![npm version](https://badge.fury.io/js/@context-pods%2Fcli.svg)](https://www.npmjs.com/package/@context-pods/cli)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Installation
+
+### Global Installation (Recommended)
+
+```bash
+npm install -g @context-pods/cli
+```
+
+### Using npx
+
+For one-off usage without installation:
+
+```bash
+npx @context-pods/create <command>
+```
+
+Note: We provide a separate [`@context-pods/create`](https://www.npmjs.com/package/@context-pods/create) package specifically for npx usage.
+
+## Usage
+
+```bash
+context-pods <command> [options]
+```
+
+## Commands
+
+### `generate [template]`
+
+Generate a new MCP server from a template.
+
+```bash
+context-pods generate
+context-pods generate typescript-basic --name my-server
+context-pods generate --output ./my-server --name weather-api
+```
+
+Options:
+
+- `-o, --output <path>` - Output directory
+- `-n, --name <name>` - MCP server name
+- `-d, --description <text>` - MCP server description
+- `-f, --force` - Overwrite existing files
+- `--var <key=value...>` - Template variables
+
+### `wrap <script> <name>`
+
+Wrap an existing script as an MCP server.
+
+```bash
+context-pods wrap ./my-script.py my-wrapper
+context-pods wrap ./analyze.sh data-analyzer --output ./servers
+```
+
+Options:
+
+- `-o, --output <path>` - Output directory
+- `-d, --description <text>` - MCP server description
+- `-t, --template <name>` - Specific template to use
+- `--var <key=value...>` - Template variables
+
+### `list`
+
+List all available MCP servers.
+
+```bash
+context-pods list
+context-pods list --format json
+context-pods list --status ready
+```
+
+Options:
+
+- `--format <format>` - Output format (table, json, summary)
+- `--status <status>` - Filter by status
+- `--search <term>` - Search in names and descriptions
+
+### `server <command>`
+
+Manage MCP servers.
+
+```bash
+context-pods server start my-server
+context-pods server stop my-server
+context-pods server status my-server
+context-pods server logs my-server
+```
+
+### `templates`
+
+List available templates.
+
+```bash
+context-pods templates
+context-pods templates --language typescript
+context-pods templates --category wrapper
+```
+
+### `build [servers...]`
+
+Build one or more MCP servers.
+
+```bash
+context-pods build
+context-pods build my-server
+context-pods build server1 server2 --parallel
+```
+
+### `dev [server]`
+
+Start development mode with hot reload.
+
+```bash
+context-pods dev my-server
+context-pods dev --all
+```
+
+### `test [servers...]`
+
+Run tests for MCP servers.
+
+```bash
+context-pods test
+context-pods test my-server
+context-pods test --coverage
+```
+
+### `init`
+
+Initialize a new Context-Pods workspace.
+
+```bash
+context-pods init
+context-pods init --turbo
+```
+
+## Configuration
+
+Context-Pods looks for configuration in the following order:
+
+1. `.context-pods.json` in the current directory
+2. `context-pods.json` in the current directory
+3. `.context-pods/config.json` in the home directory
+4. Environment variables with `CONTEXT_PODS_` prefix
+
+Example configuration:
+
+```json
+{
+  "defaultTemplate": "typescript-basic",
+  "outputDirectory": "./servers",
+  "turbo": {
+    "enabled": true,
+    "pipeline": {
+      "build": {
+        "dependsOn": ["^build"]
+      }
+    }
+  }
+}
+```
+
+## Related Packages
+
+- [`@context-pods/core`](https://www.npmjs.com/package/@context-pods/core) - Core utilities and types
+- [`@context-pods/create`](https://www.npmjs.com/package/@context-pods/create) - npx runner for quick starts
+- [`@context-pods/server`](https://www.npmjs.com/package/@context-pods/server) - MCP server implementation
+- [`@context-pods/testing`](https://www.npmjs.com/package/@context-pods/testing) - Testing framework
+
+## License
+
+MIT

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/cli",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "TurboRepo-optimized CLI for Context-Pods MCP development suite",
   "type": "module",
   "main": "./dist/cli.js",
@@ -39,7 +39,7 @@
   "author": "Conor Luddy",
   "license": "MIT",
   "dependencies": {
-    "@context-pods/core": "^0.1.3",
+    "@context-pods/core": "^0.1.4",
     "commander": "^11.1.0",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -1,6 +1,9 @@
 # @context-pods/core
 
-Core utilities and types for the Context-Pods MCP farm.
+Core utilities and types for the Context-Pods MCP (Model Context Protocol) development suite.
+
+[![npm version](https://badge.fury.io/js/@context-pods%2Fcore.svg)](https://www.npmjs.com/package/@context-pods/core)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 ## Installation
 
@@ -74,3 +77,23 @@ if (result.success) {
 ## API Reference
 
 See the TypeScript definitions for detailed API documentation.
+
+## Key Exports
+
+- **Error Classes**: `ConfigurationError`, `TemplateError`, `ValidationError`
+- **Logger**: Configurable logging with multiple levels
+- **Schemas**: Zod schemas for validation (`PodConfigSchema`, `TemplateManifestSchema`, etc.)
+- **Types**: TypeScript types for all MCP components
+- **Template Engine**: Template processing and variable substitution
+- **Template Selector**: Intelligent template selection based on context
+
+## Related Packages
+
+- [`@context-pods/cli`](https://www.npmjs.com/package/@context-pods/cli) - Command-line interface
+- [`@context-pods/create`](https://www.npmjs.com/package/@context-pods/create) - npx runner for quick starts
+- [`@context-pods/server`](https://www.npmjs.com/package/@context-pods/server) - MCP server implementation
+- [`@context-pods/testing`](https://www.npmjs.com/package/@context-pods/testing) - Testing framework
+
+## License
+
+MIT

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/core",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Core utilities and types for Context-Pods MCP farm",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create/README.md
+++ b/packages/create/README.md
@@ -1,0 +1,54 @@
+# @context-pods/create
+
+npx runner for Context-Pods MCP (Model Context Protocol) development suite.
+
+[![npm version](https://badge.fury.io/js/@context-pods%2Fcreate.svg)](https://www.npmjs.com/package/@context-pods/create)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Usage
+
+Run Context-Pods CLI directly with npx:
+
+```bash
+npx @context-pods/create generate
+npx @context-pods/create wrap ./my-script.py my-wrapper
+npx @context-pods/create list
+```
+
+This package acts as a lightweight proxy that:
+
+1. Temporarily installs the full Context-Pods CLI and its dependencies
+2. Forwards your commands to the CLI
+3. Cleans up after execution
+
+## Why this package?
+
+The main `@context-pods/cli` package uses ES modules and has dependencies that aren't automatically resolved by `npx`. This runner package solves that issue by handling the installation of all required dependencies in a temporary directory.
+
+## For regular use
+
+If you plan to use Context-Pods frequently, we recommend installing the CLI globally:
+
+```bash
+npm install -g @context-pods/cli
+```
+
+## How it works
+
+1. Creates a temporary directory
+2. Installs `@context-pods/cli` and `@context-pods/core` with all their dependencies
+3. Executes your command using the installed CLI
+4. Cleans up the temporary directory
+
+This approach ensures all dependencies are properly resolved without polluting your global or project node_modules.
+
+## Related Packages
+
+- [`@context-pods/cli`](https://www.npmjs.com/package/@context-pods/cli) - Full CLI for regular use
+- [`@context-pods/core`](https://www.npmjs.com/package/@context-pods/core) - Core utilities and types
+- [`@context-pods/server`](https://www.npmjs.com/package/@context-pods/server) - MCP server implementation
+- [`@context-pods/testing`](https://www.npmjs.com/package/@context-pods/testing) - Testing framework
+
+## License
+
+MIT

--- a/packages/create/bin/create-context-pods.js
+++ b/packages/create/bin/create-context-pods.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+
+import { execSync } from 'child_process';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+console.log('🚀 Starting Context-Pods...\n');
+
+// Create a temporary directory for the installation
+const tempDir = mkdtempSync(join(tmpdir(), 'context-pods-'));
+
+try {
+  // Install the CLI and core packages in the temp directory
+  console.log('📦 Installing Context-Pods CLI...');
+  execSync(`npm install --prefix "${tempDir}" @context-pods/cli@latest @context-pods/core@latest`, {
+    stdio: 'inherit',
+  });
+
+  // Get the CLI path
+  const cliPath = join(tempDir, 'node_modules', '@context-pods', 'cli', 'bin', 'context-pods');
+
+  // Forward all arguments to the actual CLI
+  const args = process.argv
+    .slice(2)
+    .map((arg) => `"${arg}"`)
+    .join(' ');
+
+  // Run the CLI with the forwarded arguments
+  execSync(`node "${cliPath}" ${args}`, {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  });
+} catch (error) {
+  console.error('\n❌ Error running Context-Pods:', error.message);
+  process.exit(1);
+} finally {
+  // Clean up the temporary directory
+  try {
+    rmSync(tempDir, { recursive: true, force: true });
+  } catch (cleanupError) {
+    // Ignore cleanup errors
+  }
+}

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@context-pods/create",
+  "version": "0.1.3",
+  "description": "npx runner for Context-Pods MCP development suite",
+  "type": "module",
+  "bin": {
+    "create-context-pods": "./bin/create-context-pods.js"
+  },
+  "files": [
+    "bin"
+  ],
+  "scripts": {
+    "test": "echo \"No tests for runner package\""
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "context-pods",
+    "npx",
+    "create"
+  ],
+  "author": "Conor Luddy",
+  "license": "MIT",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/create",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "npx runner for Context-Pods MCP development suite",
   "type": "module",
   "bin": {

--- a/packages/server/README.md
+++ b/packages/server/README.md
@@ -1,0 +1,187 @@
+# @context-pods/server
+
+MCP server implementation for the Context-Pods development suite.
+
+[![npm version](https://badge.fury.io/js/@context-pods%2Fserver.svg)](https://www.npmjs.com/package/@context-pods/server)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Overview
+
+This package provides a complete MCP (Model Context Protocol) server implementation with built-in support for:
+
+- Tool registration and execution
+- Resource management
+- WebSocket and stdio transports
+- Hot reloading in development
+- Comprehensive error handling
+- TypeScript support
+
+## Installation
+
+```bash
+npm install @context-pods/server
+```
+
+## Quick Start
+
+### Basic Server
+
+```typescript
+import { MCPServer } from '@context-pods/server';
+
+const server = new MCPServer({
+  name: 'my-mcp-server',
+  version: '1.0.0',
+  description: 'My awesome MCP server',
+});
+
+// Register a tool
+server.registerTool({
+  name: 'get-weather',
+  description: 'Get weather for a location',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      location: { type: 'string' },
+    },
+    required: ['location'],
+  },
+  handler: async ({ location }) => {
+    // Your tool logic here
+    return {
+      temperature: 72,
+      condition: 'sunny',
+      location,
+    };
+  },
+});
+
+// Start the server
+server.start();
+```
+
+### With Resources
+
+```typescript
+server.registerResource({
+  uri: 'weather://current/{location}',
+  name: 'Current Weather',
+  description: 'Get current weather for a location',
+  mimeType: 'application/json',
+  handler: async ({ location }) => {
+    const weather = await fetchWeather(location);
+    return {
+      content: JSON.stringify(weather),
+      mimeType: 'application/json',
+    };
+  },
+});
+```
+
+### WebSocket Server
+
+```typescript
+import { WebSocketServer } from '@context-pods/server';
+
+const wsServer = new WebSocketServer({
+  port: 3000,
+  server: mcpServer,
+});
+
+wsServer.start();
+```
+
+## Features
+
+### Tool Management
+
+- **Registration**: Easy tool registration with schema validation
+- **Execution**: Automatic parameter validation and error handling
+- **Discovery**: Built-in tool listing and introspection
+
+### Resource Management
+
+- **Dynamic Resources**: Support for parameterized resource URIs
+- **Multiple Formats**: JSON, text, binary, and custom MIME types
+- **Caching**: Built-in caching support for expensive operations
+
+### Transport Support
+
+- **stdio**: For command-line integration
+- **WebSocket**: For network-based communication
+- **Custom**: Extensible transport interface
+
+### Development Features
+
+- **Hot Reload**: Automatic server restart on code changes
+- **Debug Mode**: Comprehensive logging and error traces
+- **TypeScript**: Full type safety and IntelliSense support
+
+## Configuration
+
+```typescript
+interface ServerConfig {
+  name: string;
+  version: string;
+  description?: string;
+  capabilities?: {
+    tools?: boolean;
+    resources?: boolean;
+    prompts?: boolean;
+  };
+  transport?: 'stdio' | 'websocket' | 'custom';
+  debug?: boolean;
+}
+```
+
+## Error Handling
+
+The server includes comprehensive error handling with custom error types:
+
+```typescript
+import { ServerError, ValidationError } from '@context-pods/server';
+
+server.registerTool({
+  name: 'my-tool',
+  handler: async (params) => {
+    if (!params.required) {
+      throw new ValidationError('Missing required parameter');
+    }
+
+    try {
+      return await riskyOperation();
+    } catch (error) {
+      throw new ServerError('Operation failed', { cause: error });
+    }
+  },
+});
+```
+
+## Testing
+
+The server includes testing utilities:
+
+```typescript
+import { TestHarness } from '@context-pods/server/testing';
+
+const harness = new TestHarness(server);
+
+// Test tool execution
+const result = await harness.executeTool('get-weather', {
+  location: 'San Francisco',
+});
+
+// Test resource fetching
+const resource = await harness.fetchResource('weather://current/sf');
+```
+
+## Related Packages
+
+- [`@context-pods/core`](https://www.npmjs.com/package/@context-pods/core) - Core utilities and types
+- [`@context-pods/cli`](https://www.npmjs.com/package/@context-pods/cli) - Command-line interface
+- [`@context-pods/testing`](https://www.npmjs.com/package/@context-pods/testing) - Testing framework
+- [`@context-pods/create`](https://www.npmjs.com/package/@context-pods/create) - npx runner
+
+## License
+
+MIT

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/server",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Core MCP server for Context-Pods toolkit",
   "type": "module",
   "main": "dist/index.js",
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@context-pods/core": "^0.1.3",
+    "@context-pods/core": "^0.1.4",
     "sqlite3": "^5.1.6"
   },
   "devDependencies": {

--- a/packages/testing/README.md
+++ b/packages/testing/README.md
@@ -1,0 +1,264 @@
+# @context-pods/testing
+
+Comprehensive testing framework for MCP (Model Context Protocol) servers in the Context-Pods development suite.
+
+[![npm version](https://badge.fury.io/js/@context-pods%2Ftesting.svg)](https://www.npmjs.com/package/@context-pods/testing)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+## Overview
+
+This package provides a complete testing solution for MCP servers, including:
+
+- Protocol compliance validation
+- Script wrapper testing
+- Integration testing utilities
+- Performance benchmarking
+- Test report generation
+
+## Installation
+
+```bash
+npm install --save-dev @context-pods/testing
+```
+
+## Features
+
+### MCP Protocol Compliance Testing
+
+Validate that your MCP server correctly implements the protocol:
+
+```typescript
+import { validateMCPServer } from '@context-pods/testing';
+
+const results = await validateMCPServer('./path/to/server', {
+  checkTools: true,
+  checkResources: true,
+  checkProtocol: true,
+  timeout: 30000,
+});
+
+console.log(results.isValid); // true/false
+console.log(results.errors); // Array of validation errors
+```
+
+### Script Wrapper Testing
+
+Test wrapped scripts in multiple languages:
+
+```typescript
+import { testScriptWrapper } from '@context-pods/testing';
+
+const results = await testScriptWrapper('./my-script.py', {
+  language: 'python',
+  testCases: [
+    {
+      input: { arg1: 'value1' },
+      expectedOutput: { result: 'expected' },
+    },
+  ],
+});
+```
+
+### Test Harness
+
+Comprehensive testing harness for MCP communication:
+
+```typescript
+import { TestHarness } from '@context-pods/testing';
+
+const harness = new TestHarness({
+  serverPath: './my-mcp-server',
+  transport: 'stdio',
+});
+
+// Start the server
+await harness.start();
+
+// Test tool execution
+const result = await harness.executeTool('my-tool', {
+  param1: 'value1',
+});
+
+// Test resource fetching
+const resource = await harness.fetchResource('resource://my-resource');
+
+// Stop the server
+await harness.stop();
+```
+
+### Integration Testing
+
+```typescript
+import { MCPTestSuite } from '@context-pods/testing';
+
+const suite = new MCPTestSuite('My MCP Server Tests');
+
+suite.addTest('Tool execution test', async (harness) => {
+  const result = await harness.executeTool('calculate', {
+    operation: 'add',
+    a: 5,
+    b: 3,
+  });
+
+  expect(result).toEqual({ result: 8 });
+});
+
+suite.addTest('Resource fetching test', async (harness) => {
+  const resource = await harness.fetchResource('data://config');
+  expect(resource.mimeType).toBe('application/json');
+});
+
+// Run all tests
+const results = await suite.run();
+```
+
+### Performance Benchmarking
+
+```typescript
+import { benchmark } from '@context-pods/testing';
+
+const results = await benchmark({
+  serverPath: './my-mcp-server',
+  iterations: 100,
+  tools: ['tool1', 'tool2'],
+  concurrent: 10,
+});
+
+console.log(results.averageResponseTime);
+console.log(results.throughput);
+```
+
+### Report Generation
+
+Generate test reports in multiple formats:
+
+```typescript
+import { generateReport } from '@context-pods/testing';
+
+// HTML report
+await generateReport(testResults, {
+  format: 'html',
+  outputPath: './test-report.html',
+  includeGraphs: true,
+});
+
+// JUnit XML for CI/CD
+await generateReport(testResults, {
+  format: 'junit',
+  outputPath: './junit.xml',
+});
+
+// Markdown for documentation
+await generateReport(testResults, {
+  format: 'markdown',
+  outputPath: './test-results.md',
+});
+```
+
+## CLI Usage
+
+The package includes a CLI for quick testing:
+
+```bash
+# Validate MCP compliance
+npx @context-pods/testing validate ./my-server
+
+# Test a wrapped script
+npx @context-pods/testing test-wrapper ./script.py --language python
+
+# Run a test suite
+npx @context-pods/testing run ./test-suite.js
+
+# Generate a report
+npx @context-pods/testing report ./results.json --format html
+```
+
+## Configuration
+
+Create a `.mcp-test.json` file for test configuration:
+
+```json
+{
+  "defaultTimeout": 30000,
+  "transport": "stdio",
+  "validation": {
+    "strict": true,
+    "checkTools": true,
+    "checkResources": true,
+    "checkProtocol": true
+  },
+  "reporting": {
+    "format": "html",
+    "outputDir": "./test-reports"
+  }
+}
+```
+
+## Writing Test Cases
+
+### Basic Test
+
+```typescript
+import { describe, it, expect } from '@context-pods/testing';
+
+describe('My MCP Server', () => {
+  it('should execute the greeting tool', async (harness) => {
+    const result = await harness.executeTool('greet', {
+      name: 'World',
+    });
+
+    expect(result).toBe('Hello, World!');
+  });
+});
+```
+
+### Advanced Test with Setup
+
+```typescript
+import { TestSuite } from '@context-pods/testing';
+
+const suite = new TestSuite({
+  serverPath: './my-server',
+
+  beforeAll: async (harness) => {
+    // Global setup
+    await harness.initialize();
+  },
+
+  beforeEach: async (harness) => {
+    // Test-specific setup
+    await harness.reset();
+  },
+
+  afterEach: async (harness) => {
+    // Test cleanup
+    await harness.cleanup();
+  },
+
+  afterAll: async (harness) => {
+    // Global cleanup
+    await harness.shutdown();
+  },
+});
+```
+
+## Validation Schemas
+
+The testing framework uses Zod schemas to validate MCP protocol compliance:
+
+- Tool definitions
+- Resource definitions
+- Request/response formats
+- Error handling
+- Protocol negotiation
+
+## Related Packages
+
+- [`@context-pods/core`](https://www.npmjs.com/package/@context-pods/core) - Core utilities and types
+- [`@context-pods/cli`](https://www.npmjs.com/package/@context-pods/cli) - Command-line interface
+- [`@context-pods/server`](https://www.npmjs.com/package/@context-pods/server) - MCP server implementation
+- [`@context-pods/create`](https://www.npmjs.com/package/@context-pods/create) - npx runner
+
+## License
+
+MIT

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/testing",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Comprehensive testing and validation framework for Context-Pods MCP servers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Created new `@context-pods/create` package to enable npx execution
- Added comprehensive README documentation for all npm packages  
- Fixed dependency resolution issues when running via npx

## Problem
Users were unable to run `npx @context-pods/cli generate` due to ES module dependency resolution issues.

## Solution
Created a lightweight npx runner package that:
1. Installs both CLI and core packages in a temporary directory
2. Forwards commands to the actual CLI
3. Cleans up after execution

## Usage
Users can now run:
```bash
npx @context-pods/create generate
npx @context-pods/create list
npx @context-pods/create wrap ./script.py my-wrapper
```

## Test plan
- [x] Linting passes for all packages
- [x] Tests pass for all packages
- [x] Build succeeds for all packages
- [x] Pre-commit hooks pass
- [x] Tested npx execution locally

🤖 Generated with [Claude Code](https://claude.ai/code)