### PR TITLE
feat: Bundle templates as separate npm package

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,15 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+*.tsbuildinfo
+
+# Test coverage
+coverage/
+
+# Generated files
+generated/
+
+# Template files (these contain placeholders and shouldn't be linted)
+packages/templates/templates/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-pods",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-pods",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -123,6 +123,10 @@
     },
     "node_modules/@context-pods/server": {
       "resolved": "packages/server",
+      "link": true
+    },
+    "node_modules/@context-pods/templates": {
+      "resolved": "packages/templates",
       "link": true
     },
     "node_modules/@context-pods/testing": {
@@ -7502,10 +7506,11 @@
     },
     "packages/cli": {
       "name": "@context-pods/cli",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@context-pods/core": "^0.1.4",
+        "@context-pods/templates": "^0.1.4",
         "chalk": "^5.3.0",
         "chokidar": "^3.6.0",
         "commander": "^11.1.0",
@@ -7634,9 +7639,10 @@
     },
     "packages/core": {
       "name": "@context-pods/core",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
+        "@context-pods/templates": "^0.1.4",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -7645,7 +7651,7 @@
     },
     "packages/create": {
       "name": "@context-pods/create",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "bin": {
         "create-context-pods": "bin/create-context-pods.js"
@@ -7656,9 +7662,10 @@
     },
     "packages/server": {
       "name": "@context-pods/server",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "dependencies": {
         "@context-pods/core": "^0.1.4",
+        "@context-pods/templates": "^0.1.4",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "sqlite3": "^5.1.6"
       },
@@ -7673,9 +7680,20 @@
         "vitest": "^1.6.0"
       }
     },
+    "packages/templates": {
+      "name": "@context-pods/templates",
+      "version": "0.1.5",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^3.23.0"
+      },
+      "devDependencies": {
+        "@types/node": "^20.14.0"
+      }
+    },
     "packages/testing": {
       "name": "@context-pods/testing",
-      "version": "0.1.4",
+      "version": "0.1.5",
       "license": "MIT",
       "dependencies": {
         "@context-pods/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-pods",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "ContextPods - a developer tool that generates functional MCP servers from templates",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/cli",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "TurboRepo-optimized CLI for Context-Pods MCP development suite",
   "type": "module",
   "main": "./dist/cli.js",
@@ -17,7 +17,6 @@
   "files": [
     "dist",
     "bin",
-    "templates",
     "README.md"
   ],
   "scripts": {
@@ -40,6 +39,7 @@
   "license": "MIT",
   "dependencies": {
     "@context-pods/core": "^0.1.4",
+    "@context-pods/templates": "^0.1.4",
     "commander": "^11.1.0",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/create",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "npx runner for Context-Pods MCP development suite",
   "type": "module",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/server",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Core MCP server for Context-Pods toolkit",
   "type": "module",
   "main": "dist/index.js",
@@ -9,8 +9,7 @@
     "context-pods-server": "bin/server.js"
   },
   "scripts": {
-    "build": "tsc && npm run copy-templates",
-    "copy-templates": "rm -rf ./templates && cp -r ../../templates ./templates",
+    "build": "tsc",
     "dev": "tsc --watch",
     "test": "vitest run --reporter=verbose --passWithNoTests",
     "test:coverage": "vitest run --reporter=verbose --passWithNoTests --coverage",
@@ -21,6 +20,7 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
     "@context-pods/core": "^0.1.4",
+    "@context-pods/templates": "^0.1.4",
     "sqlite3": "^5.1.6"
   },
   "devDependencies": {
@@ -32,7 +32,6 @@
   },
   "files": [
     "dist",
-    "bin",
-    "templates"
+    "bin"
   ]
 }

--- a/packages/templates/.eslintignore
+++ b/packages/templates/.eslintignore
@@ -1,0 +1,1 @@
+templates/**/*

--- a/packages/templates/README.md
+++ b/packages/templates/README.md
@@ -1,0 +1,40 @@
+# @context-pods/templates
+
+Template collection for Context-Pods MCP server generation.
+
+## Overview
+
+This package provides the official templates used by Context-Pods for generating MCP servers. Templates are bundled with the package during build time, making them available for both CLI and programmatic use.
+
+## Usage
+
+```typescript
+import { getAvailableTemplates, getTemplate, templatesPath } from '@context-pods/templates';
+
+// Get all available templates
+const templates = getAvailableTemplates();
+
+// Get a specific template
+const basicTemplate = getTemplate('basic');
+
+// Get the templates directory path
+const path = templatesPath;
+```
+
+## Available Templates
+
+- **basic** - Basic TypeScript MCP server template
+- **python-basic** - Basic Python MCP server template
+- **typescript-advanced** - Advanced TypeScript template with full utilities
+
+## Template Structure
+
+Each template includes:
+
+- `template.json` - Template metadata and configuration
+- Source files with Mustache placeholders for variable substitution
+- README.md with template-specific documentation
+
+## Development
+
+Templates are stored in the root `/templates` directory and copied to this package during build.

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@context-pods/core",
+  "name": "@context-pods/templates",
   "version": "0.1.5",
-  "description": "Core utilities and types for Context-Pods MCP farm",
+  "description": "Template collection for Context-Pods MCP server generation",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -9,30 +9,32 @@
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
-    }
+    },
+    "./templates/*": "./templates/*"
   },
   "files": [
     "dist",
+    "templates",
     "README.md"
   ],
   "scripts": {
-    "build": "tsc -b",
-    "clean": "rm -rf dist tsconfig.tsbuildinfo",
+    "build": "tsc -b && npm run copy:templates",
+    "copy:templates": "cp -r ../../templates ./",
+    "clean": "rm -rf dist tsconfig.tsbuildinfo templates",
     "test": "vitest run --reporter=verbose --passWithNoTests",
-    "test:coverage": "vitest run --reporter=verbose --passWithNoTests --coverage",
     "lint": "eslint src --ext .ts",
     "format": "prettier --write \"src/**/*.ts\""
   },
   "keywords": [
     "mcp",
     "model-context-protocol",
-    "context-pods"
+    "context-pods",
+    "templates"
   ],
   "author": "Conor Luddy",
   "license": "MIT",
   "dependencies": {
-    "zod": "^3.23.0",
-    "@context-pods/templates": "^0.1.4"
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@types/node": "^20.14.0"

--- a/packages/templates/src/index.ts
+++ b/packages/templates/src/index.ts
@@ -1,0 +1,104 @@
+/**
+ * @context-pods/templates - Template collection for MCP server generation
+ *
+ * This package provides:
+ * - Template metadata and discovery
+ * - Template validation
+ * - Template path resolution
+ */
+
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { existsSync, readdirSync, readFileSync } from 'fs';
+
+/**
+ * Get the directory containing this module
+ */
+function getModuleDir(): string {
+  // Handle both CommonJS and ES modules
+  if (typeof __dirname !== 'undefined') {
+    return __dirname;
+  }
+
+  // ES module fallback
+  const __filename = fileURLToPath(import.meta.url);
+  return dirname(__filename);
+}
+
+/**
+ * Get the path to the templates directory
+ */
+export function getTemplatesPath(): string {
+  const moduleDir = getModuleDir();
+  // Templates are copied to the package root during build
+  return join(dirname(moduleDir), 'templates');
+}
+
+/**
+ * Template metadata interface
+ */
+export interface TemplateMetadata {
+  name: string;
+  language: string;
+  description: string;
+  path: string;
+}
+
+/**
+ * Get all available templates
+ */
+export function getAvailableTemplates(): TemplateMetadata[] {
+  const templatesPath = getTemplatesPath();
+
+  if (!existsSync(templatesPath)) {
+    throw new Error(`Templates directory not found: ${templatesPath}`);
+  }
+
+  const templates: TemplateMetadata[] = [];
+  const items = readdirSync(templatesPath, { withFileTypes: true });
+
+  for (const item of items) {
+    if (item.isDirectory()) {
+      const templatePath = join(templatesPath, item.name);
+      const metadataPath = join(templatePath, 'template.json');
+
+      if (existsSync(metadataPath)) {
+        try {
+          const metadataContent = readFileSync(metadataPath, 'utf8');
+          const metadata = JSON.parse(metadataContent) as {
+            language?: string;
+            description?: string;
+          };
+          templates.push({
+            name: item.name,
+            language: metadata.language ?? 'unknown',
+            description: metadata.description ?? 'No description available',
+            path: templatePath,
+          });
+        } catch (error) {
+          console.warn(`Failed to load template metadata for ${item.name}:`, error);
+        }
+      }
+    }
+  }
+
+  return templates;
+}
+
+/**
+ * Get a specific template by name
+ */
+export function getTemplate(name: string): TemplateMetadata | null {
+  const templates = getAvailableTemplates();
+  return templates.find((t) => t.name === name) || null;
+}
+
+/**
+ * Check if a template exists
+ */
+export function templateExists(name: string): boolean {
+  return getTemplate(name) !== null;
+}
+
+// Re-export for convenience
+export { getTemplatesPath as templatesPath };

--- a/packages/templates/templates/basic/README.md
+++ b/packages/templates/templates/basic/README.md
@@ -1,0 +1,50 @@
+# {{serverName}}
+
+{{serverDescription}}
+
+## Installation
+
+```bash
+npm install
+npm run build
+```
+
+## Usage
+
+This MCP server can be used with any MCP-compatible client.
+
+### Available Tools
+
+- **example-tool**: An example tool that echoes input
+
+### Available Resources
+
+- **{{serverName}}://example**: An example resource
+
+## Development
+
+```bash
+# Build the server
+npm run build
+
+# Run in development mode with auto-reload
+npm run dev
+
+# Run the server
+npm start
+```
+
+## Configuration
+
+Add this server to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "{{serverName}}": {
+      "command": "node",
+      "args": ["path/to/{{serverName}}/dist/index.js"]
+    }
+  }
+}
+```

--- a/packages/templates/templates/basic/package.json
+++ b/packages/templates/templates/basic/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "{{serverName}}",
+  "version": "0.1.0",
+  "description": "{{serverDescription}}",
+  "type": "module",
+  "main": "./dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "dev": "node --watch dist/index.js",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.5.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.14.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/packages/templates/templates/basic/src/index.ts
+++ b/packages/templates/templates/basic/src/index.ts
@@ -1,0 +1,116 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  ListResourcesRequestSchema,
+  ListToolsRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+
+/**
+ * {{serverDescription}}
+ */
+const server = new Server(
+  {
+    name: '{{serverName}}',
+    version: '0.1.0',
+  },
+  {
+    capabilities: {
+      tools: {},
+      resources: {},
+    },
+  },
+);
+
+/**
+ * List available tools
+ */
+server.setRequestHandler(ListToolsRequestSchema, async () => {
+  return {
+    tools: [
+      {
+        name: 'example-tool',
+        description: 'An example tool that echoes input',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            message: {
+              type: 'string',
+              description: 'Message to echo',
+            },
+          },
+          required: ['message'],
+        },
+      },
+    ],
+  };
+});
+
+/**
+ * Handle tool calls
+ */
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  if (request.params.name === 'example-tool') {
+    const { message } = request.params.arguments as { message: string };
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Echo: ${message}`,
+        },
+      ],
+    };
+  }
+
+  throw new Error(`Unknown tool: ${request.params.name}`);
+});
+
+/**
+ * List available resources
+ */
+server.setRequestHandler(ListResourcesRequestSchema, async () => {
+  return {
+    resources: [
+      {
+        uri: '{{serverName}}://example',
+        name: 'Example Resource',
+        description: 'An example resource',
+        mimeType: 'text/plain',
+      },
+    ],
+  };
+});
+
+/**
+ * Read resource content
+ */
+server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+  if (request.params.uri === '{{serverName}}://example') {
+    return {
+      contents: [
+        {
+          uri: request.params.uri,
+          mimeType: 'text/plain',
+          text: 'This is an example resource from {{serverName}}',
+        },
+      ],
+    };
+  }
+
+  throw new Error(`Unknown resource: ${request.params.uri}`);
+});
+
+/**
+ * Start the server
+ */
+async function main() {
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+  console.error('{{serverName}} MCP server started');
+}
+
+main().catch((error) => {
+  console.error('Server error:', error);
+  process.exit(1);
+});

--- a/packages/templates/templates/basic/template.json
+++ b/packages/templates/templates/basic/template.json
@@ -1,0 +1,72 @@
+{
+  "name": "basic",
+  "description": "Basic MCP server template with TypeScript and TurboRepo optimization",
+  "version": "1.0.0",
+  "author": "Context-Pods Team",
+  "tags": ["starter", "minimal", "typescript"],
+  "language": "typescript",
+  "optimization": {
+    "turboRepo": true,
+    "hotReload": true,
+    "sharedDependencies": true,
+    "buildCaching": true
+  },
+  "variables": {
+    "serverName": {
+      "description": "Name of the MCP server",
+      "type": "string",
+      "required": true,
+      "validation": {
+        "pattern": "^[a-z0-9-]+$"
+      }
+    },
+    "serverDescription": {
+      "description": "Description of the MCP server",
+      "type": "string",
+      "required": true
+    },
+    "includeExamples": {
+      "description": "Include example tools and resources",
+      "type": "boolean",
+      "required": false,
+      "default": true
+    }
+  },
+  "files": [
+    {
+      "path": "package.json",
+      "template": true
+    },
+    {
+      "path": "tsconfig.json",
+      "template": false
+    },
+    {
+      "path": "src/index.ts",
+      "template": true
+    },
+    {
+      "path": "README.md",
+      "template": true
+    }
+  ],
+  "dependencies": {
+    "core": ["@context-pods/core"],
+    "dev": ["@types/node", "typescript", "tsx"],
+    "peer": ["@modelcontextprotocol/sdk"]
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "type-check": "tsc --noEmit"
+  },
+  "mcpConfig": {
+    "defaultCommand": "node",
+    "defaultArgs": ["dist/index.js"],
+    "defaultEnv": {
+      "NODE_ENV": "production"
+    },
+    "generateByDefault": true
+  }
+}

--- a/packages/templates/templates/basic/tsconfig.json
+++ b/packages/templates/templates/basic/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/templates/templates/python-basic/README.md
+++ b/packages/templates/templates/python-basic/README.md
@@ -1,0 +1,70 @@
+# {{serverName}}
+
+{{serverDescription}}
+
+## Overview
+
+This is a Model Context Protocol (MCP) server implementation in Python. It provides tools and resources that can be used by MCP clients.
+
+## Installation
+
+```bash
+# Install dependencies
+pip install -r requirements.txt
+```
+
+## Usage
+
+### Running the Server
+
+```bash
+python main.py
+```
+
+### Configuring with MCP Clients
+
+To use this server with an MCP client, add the following configuration:
+
+```json
+{
+  "mcpServers": {
+    "{{serverName}}": {
+      "command": "python",
+      "args": ["/path/to/{{serverName}}/main.py"]
+    }
+  }
+}
+```
+
+## Available Tools
+
+- **example_tool**: An example tool that echoes the input message
+
+## Available Resources
+
+- **{{serverName}}://example**: An example resource demonstrating the resource system
+
+## Development
+
+### Adding New Tools
+
+1. Open `src/tools.py`
+2. Add your tool definition to the `get_tools()` function
+3. Add the tool handler in the `handle_tool_call()` function
+
+### Adding New Resources
+
+1. Open `src/resources.py`
+2. Add your resource definition to the `get_resources()` function
+3. Add the resource handler in the `handle_resource_read()` function
+
+## Testing
+
+```bash
+# Run tests (if available)
+python -m pytest tests/
+```
+
+## License
+
+MIT

--- a/packages/templates/templates/python-basic/main.py
+++ b/packages/templates/templates/python-basic/main.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""
+{{serverDescription}}
+
+Self-contained Python MCP server
+"""
+
+import asyncio
+import sys
+from src.server import create_server
+
+
+async def main():
+    """Main entry point for the {{serverName}} MCP server"""
+    try:
+        print(f"Starting {{serverName}} MCP server...", file=sys.stderr)
+        
+        server = await create_server()
+        
+        print(f"{{serverName}} MCP server started successfully", file=sys.stderr)
+        
+        # Keep the server running
+        await server.run()
+        
+    except Exception as error:
+        print(f"Failed to start {{serverName}} MCP server: {error}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/templates/templates/python-basic/requirements.txt
+++ b/packages/templates/templates/python-basic/requirements.txt
@@ -1,0 +1,6 @@
+# MCP SDK for Python
+mcp>=0.5.0
+
+# Development dependencies (optional)
+pytest>=7.0.0
+flake8>=6.0.0

--- a/packages/templates/templates/python-basic/src/__init__.py
+++ b/packages/templates/templates/python-basic/src/__init__.py
@@ -1,0 +1,7 @@
+"""
+{{serverName}} - {{serverDescription}}
+
+A Model Context Protocol (MCP) server implementation.
+"""
+
+__version__ = "0.0.1"

--- a/packages/templates/templates/python-basic/src/resources.py
+++ b/packages/templates/templates/python-basic/src/resources.py
@@ -1,0 +1,42 @@
+"""
+Resource implementations for {{serverName}}
+"""
+
+from typing import List
+from mcp.types import Resource
+
+
+def get_resources() -> List[Resource]:
+    """
+    Return the list of available resources.
+    
+    Add your custom resources here.
+    """
+    return [
+        Resource(
+            uri="{{serverName}}://example",
+            name="Example Resource",
+            description="An example resource that demonstrates the resource system",
+            mimeType="text/plain"
+        ),
+        # Add more resources here
+    ]
+
+
+async def handle_resource_read(uri: str) -> str:
+    """
+    Handle resource reading.
+    
+    Args:
+        uri: The URI of the resource to read
+        
+    Returns:
+        The content of the resource
+    """
+    
+    if uri == "{{serverName}}://example":
+        return "This is an example resource content for {{serverName}}"
+    
+    # Add more resource handlers here
+    
+    raise ValueError(f"Unknown resource: {uri}")

--- a/packages/templates/templates/python-basic/src/server.py
+++ b/packages/templates/templates/python-basic/src/server.py
@@ -1,0 +1,75 @@
+"""
+MCP Server implementation for {{serverName}}
+"""
+
+import asyncio
+import logging
+from typing import Dict, List, Any
+
+from mcp.server import Server
+from mcp.server.models import InitializationOptions
+from mcp.types import Tool, Resource
+
+from .tools import get_tools, handle_tool_call
+from .resources import get_resources, handle_resource_read
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+
+class {{serverName}}Server:
+    """
+    {{serverDescription}}
+    """
+    
+    def __init__(self):
+        self.server = Server("{{serverName}}")
+        self._setup_handlers()
+    
+    def _setup_handlers(self):
+        """Set up server request handlers"""
+        
+        @self.server.list_tools()
+        async def handle_list_tools() -> List[Tool]:
+            """List available tools"""
+            return get_tools()
+        
+        @self.server.call_tool()
+        async def handle_call_tool(name: str, arguments: Dict[str, Any]) -> Any:
+            """Handle tool execution"""
+            return await handle_tool_call(name, arguments)
+        
+        @self.server.list_resources()
+        async def handle_list_resources() -> List[Resource]:
+            """List available resources"""
+            return get_resources()
+        
+        @self.server.read_resource()
+        async def handle_read_resource(uri: str) -> str:
+            """Read a specific resource"""
+            return await handle_resource_read(uri)
+    
+    async def run(self):
+        """Run the MCP server"""
+        from mcp.server.stdio import stdio_server
+        
+        async with stdio_server() as (read_stream, write_stream):
+            await self.server.run(
+                read_stream,
+                write_stream,
+                InitializationOptions(
+                    server_name="{{serverName}}",
+                    server_version="0.0.1"
+                )
+            )
+
+
+async def main():
+    """Main entry point"""
+    server = {{serverName}}Server()
+    await server.run()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/packages/templates/templates/python-basic/src/tools.py
+++ b/packages/templates/templates/python-basic/src/tools.py
@@ -1,0 +1,55 @@
+"""
+Tool implementations for {{serverName}}
+"""
+
+from typing import Dict, List, Any
+from mcp.types import Tool
+
+
+def get_tools() -> List[Tool]:
+    """
+    Return the list of available tools.
+    
+    Add your custom tools here.
+    """
+    return [
+        Tool(
+            name="example_tool",
+            description="An example tool that echoes the input",
+            inputSchema={
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "Message to echo"
+                    }
+                },
+                "required": ["message"]
+            }
+        ),
+        # Add more tools here
+    ]
+
+
+async def handle_tool_call(name: str, arguments: Dict[str, Any]) -> Any:
+    """
+    Handle tool execution.
+    
+    Args:
+        name: The name of the tool to execute
+        arguments: The arguments passed to the tool
+        
+    Returns:
+        The result of the tool execution
+    """
+    
+    if name == "example_tool":
+        message = arguments.get("message", "")
+        return {
+            "echo": message,
+            "length": len(message)
+        }
+    
+    # Add more tool handlers here
+    
+    raise ValueError(f"Unknown tool: {name}")

--- a/packages/templates/templates/python-basic/template.json
+++ b/packages/templates/templates/python-basic/template.json
@@ -1,0 +1,84 @@
+{
+  "name": "python-basic",
+  "description": "Basic Python MCP server template (self-contained)",
+  "version": "1.0.0",
+  "author": "Context-Pods Team",
+  "tags": ["python", "basic", "self-contained"],
+  "language": "python",
+  "optimization": {
+    "turboRepo": false,
+    "hotReload": false,
+    "sharedDependencies": false,
+    "buildCaching": false
+  },
+  "variables": {
+    "serverName": {
+      "description": "Name of the MCP server",
+      "type": "string",
+      "required": true,
+      "validation": {
+        "pattern": "^[a-z0-9_]+$"
+      }
+    },
+    "serverDescription": {
+      "description": "Description of the MCP server",
+      "type": "string",
+      "required": true
+    },
+    "pythonVersion": {
+      "description": "Minimum Python version required",
+      "type": "string",
+      "required": false,
+      "default": "3.8",
+      "validation": {
+        "options": ["3.8", "3.9", "3.10", "3.11", "3.12"]
+      }
+    }
+  },
+  "files": [
+    {
+      "path": "main.py",
+      "template": true,
+      "executable": true
+    },
+    {
+      "path": "requirements.txt",
+      "template": true
+    },
+    {
+      "path": "src/__init__.py",
+      "template": false
+    },
+    {
+      "path": "src/server.py",
+      "template": true
+    },
+    {
+      "path": "src/tools.py",
+      "template": true
+    },
+    {
+      "path": "src/resources.py",
+      "template": true
+    },
+    {
+      "path": "README.md",
+      "template": true
+    }
+  ],
+  "scripts": {
+    "install": "pip install -r requirements.txt",
+    "dev": "python main.py",
+    "start": "python main.py",
+    "test": "python -m pytest tests/",
+    "lint": "python -m flake8 src/ main.py"
+  },
+  "mcpConfig": {
+    "defaultCommand": "python",
+    "defaultArgs": ["main.py"],
+    "defaultEnv": {
+      "PYTHONPATH": "."
+    },
+    "generateByDefault": true
+  }
+}

--- a/packages/templates/templates/typescript-advanced/.env.example
+++ b/packages/templates/templates/typescript-advanced/.env.example
@@ -1,0 +1,15 @@
+# Environment Configuration
+
+# Node environment (development, production, test)
+NODE_ENV=development
+
+# Logging level (debug, info, warn, error)
+LOG_LEVEL=info
+
+# Server configuration
+# PORT=3000
+# HOST=localhost
+
+# Add your custom environment variables below
+# API_KEY=your-api-key-here
+# DATABASE_URL=your-database-url-here

--- a/packages/templates/templates/typescript-advanced/EXAMPLES.md
+++ b/packages/templates/templates/typescript-advanced/EXAMPLES.md
@@ -1,0 +1,286 @@
+# TypeScript Advanced Template Examples
+
+This file provides specific examples for using the TypeScript Advanced template.
+
+## Basic Generation
+
+```bash
+npx @context-pods/cli generate typescript-advanced \
+  --name my-advanced-server \
+  --description "An advanced MCP server with full features"
+```
+
+## With All Features Enabled
+
+```bash
+npx @context-pods/cli generate typescript-advanced \
+  --name full-featured-server \
+  --description "MCP server with all features enabled" \
+  --includeTools true \
+  --includeResources true \
+  --includePrompts true \
+  --toolCategories '["file", "data", "utility", "network", "system"]'
+```
+
+## Custom Tool Categories
+
+```bash
+# File and network operations only
+npx @context-pods/cli generate typescript-advanced \
+  --name file-network-server \
+  --includeTools true \
+  --toolCategories '["file", "network"]'
+
+# Data processing focus
+npx @context-pods/cli generate typescript-advanced \
+  --name data-processor \
+  --includeTools true \
+  --toolCategories '["data", "utility"]'
+```
+
+## Configuration File Example
+
+Create a `config.json`:
+
+```json
+{
+  "serverName": "enterprise-server",
+  "description": "Enterprise-grade MCP server",
+  "author": "Enterprise Team",
+  "license": "Apache-2.0",
+  "version": "1.0.0",
+  "includeTools": true,
+  "includeResources": true,
+  "includePrompts": false,
+  "toolCategories": ["file", "data", "system"],
+  "useStrictMode": true,
+  "nodeVersion": "20"
+}
+```
+
+Then generate:
+
+```bash
+npx @context-pods/cli generate typescript-advanced --config config.json
+```
+
+## Post-Generation Customization
+
+After generation, you can extend the server:
+
+### Adding a Custom Tool
+
+1. Create a new tool file in `src/tools/`:
+
+```typescript
+// src/tools/custom-tool.ts
+import { Tool } from '@modelcontextprotocol/sdk/types.js';
+
+export const myCustomTool: Tool = {
+  name: 'my_custom_tool',
+  description: 'A custom tool for specific operations',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      input: {
+        type: 'string',
+        description: 'Input for the tool',
+      },
+    },
+    required: ['input'],
+  },
+};
+
+export async function handleMyCustomTool(params: any) {
+  const { input } = params;
+
+  // Your custom logic here
+  return {
+    content: [
+      {
+        type: 'text',
+        text: `Processed: ${input}`,
+      },
+    ],
+  };
+}
+```
+
+2. Register it in `src/index.ts`:
+
+```typescript
+import { myCustomTool, handleMyCustomTool } from './tools/custom-tool.js';
+
+// In the tools registration section
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    // ... existing tools
+    myCustomTool,
+  ],
+}));
+
+// In the tool execution section
+if (params.name === 'my_custom_tool') {
+  return handleMyCustomTool(params.arguments);
+}
+```
+
+### Adding a Resource
+
+```typescript
+// src/resources/custom-resource.ts
+import { Resource } from '@modelcontextprotocol/sdk/types.js';
+
+export const customResource: Resource = {
+  uri: 'custom://my-resource',
+  name: 'My Custom Resource',
+  description: 'A custom resource with dynamic content',
+  mimeType: 'application/json',
+};
+
+export async function getCustomResourceContent() {
+  return {
+    content: [
+      {
+        type: 'text',
+        text: JSON.stringify(
+          {
+            timestamp: new Date().toISOString(),
+            data: 'Custom resource data',
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+  };
+}
+```
+
+## Environment Variables
+
+The template supports these environment variables:
+
+```bash
+# Set log level
+LOG_LEVEL=debug npm start
+
+# Node environment
+NODE_ENV=production npm start
+
+# Custom server configuration
+MCP_SERVER_NAME="My Custom Server" npm start
+```
+
+## Testing Your Server
+
+```bash
+# Run all tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Test specific functionality
+npm test -- --grep "tool execution"
+
+# Test with coverage
+npm run test:coverage
+```
+
+## Building for Production
+
+```bash
+# Clean previous build
+npm run clean
+
+# Build for production
+npm run build
+
+# Type check without building
+npm run type-check
+
+# Lint code
+npm run lint
+
+# Format code
+npm run format
+```
+
+## Integration Examples
+
+### With Claude Desktop
+
+```json
+{
+  "mcpServers": {
+    "my-advanced-server": {
+      "command": "node",
+      "args": ["path/to/my-advanced-server/dist/index.js"],
+      "env": {
+        "LOG_LEVEL": "info"
+      }
+    }
+  }
+}
+```
+
+### With Continue
+
+```json
+{
+  "models": [...],
+  "mcpServers": {
+    "my-advanced-server": {
+      "command": "node",
+      "args": ["./dist/index.js"],
+      "cwd": "path/to/my-advanced-server"
+    }
+  }
+}
+```
+
+## Troubleshooting
+
+### TypeScript Errors
+
+If you encounter TypeScript errors after generation:
+
+```bash
+# Ensure all dependencies are installed
+npm install
+
+# Check TypeScript version
+npx tsc --version
+
+# Run type checking
+npm run type-check
+```
+
+### Missing Dependencies
+
+If tools fail due to missing dependencies:
+
+```bash
+# For file operations
+npm install @types/node
+
+# For network operations
+npm install axios @types/axios
+
+# For data processing
+npm install lodash @types/lodash
+```
+
+### Build Issues
+
+```bash
+# Clean and rebuild
+npm run clean && npm run build
+
+# Check for conflicting global types
+npm ls @types/node
+
+# Ensure tsconfig is correct
+cat tsconfig.json
+```

--- a/packages/templates/templates/typescript-advanced/README.md
+++ b/packages/templates/templates/typescript-advanced/README.md
@@ -1,0 +1,175 @@
+# {{serverName}}
+
+{{serverDescription}}
+
+## Overview
+
+This is an advanced TypeScript Model Context Protocol (MCP) server implementation with full TurboRepo optimization and Context-Pods utilities. It provides a robust foundation for building production-ready MCP servers.
+
+## Features
+
+- 🚀 **TurboRepo Optimized** - Fast builds with caching and hot reloading
+- 📦 **Context-Pods Integration** - Leverages shared utilities and components
+- 🛡️ **Type Safety** - Full TypeScript support with strict typing
+- 📝 **Structured Logging** - Built-in logging with Context-Pods logger
+- ⚡ **Hot Reload** - Development mode with instant feedback
+- 🧪 **Testing** - Comprehensive test setup with Vitest
+
+## Installation
+
+```bash
+# Install dependencies
+npm install
+
+# Build the project
+npm run build
+```
+
+## Usage
+
+### Development Mode
+
+```bash
+# Run with hot reloading
+npm run dev
+```
+
+### Production Mode
+
+```bash
+# Build and run
+npm run build
+npm start
+```
+
+### Configuring with MCP Clients
+
+Add the following to your MCP client configuration:
+
+```json
+{
+  "mcpServers": {
+    "{{serverName}}": {
+      "command": "node",
+      "args": ["/path/to/{{serverName}}/dist/index.js"],
+      "env": {
+        "NODE_ENV": "production"
+      }
+    }
+  }
+}
+```
+
+## Available Tools
+
+{{#if toolCategories}}
+{{#each toolCategories}}
+
+### {{this}} Tools
+
+- Tools for {{this}} operations
+  {{/each}}
+  {{else}}
+- **Example Tool** - Demonstrates tool implementation
+  {{/if}}
+
+## Available Resources
+
+- **{{serverName}}://status** - Server status and health information
+- **{{serverName}}://config** - Current configuration
+
+## Project Structure
+
+```
+{{serverName}}/
+├── src/
+│   ├── index.ts          # Entry point
+│   ├── server.ts         # MCP server setup
+│   ├── tools/            # Tool implementations
+│   │   ├── index.ts
+│   │   ├── file-tools.ts
+│   │   ├── data-tools.ts
+│   │   └── utility-tools.ts
+│   ├── resources/        # Resource implementations
+│   │   └── index.ts
+│   └── utils/            # Utility functions
+│       ├── validation.ts
+│       ├── helpers.ts
+│       └── logger.ts
+├── tests/                # Test files
+├── dist/                 # Compiled output
+└── package.json
+```
+
+## Development
+
+### Adding New Tools
+
+1. Create a new file in `src/tools/` or add to existing category files
+2. Export your tool from `src/tools/index.ts`
+3. Tools are automatically registered with the server
+
+Example:
+
+```typescript
+export const myTool: Tool = {
+  name: 'my-tool',
+  description: 'Description of what the tool does',
+  inputSchema: {
+    type: 'object',
+    properties: {
+      param: { type: 'string', description: 'Parameter description' },
+    },
+    required: ['param'],
+  },
+  handler: async (args) => {
+    // Implementation
+    return { result: 'success' };
+  },
+};
+```
+
+### Adding New Resources
+
+1. Add resources to `src/resources/index.ts`
+2. Resources are automatically registered with the server
+
+### Environment Variables
+
+Create a `.env` file based on `.env.example`:
+
+```bash
+cp .env.example .env
+```
+
+Available environment variables:
+
+- `NODE_ENV` - Environment mode (development/production)
+- `LOG_LEVEL` - Logging level (debug/info/warn/error)
+
+## Testing
+
+```bash
+# Run tests
+npm test
+
+# Run tests in watch mode
+npm run test:watch
+
+# Type checking
+npm run type-check
+```
+
+## Scripts
+
+- `npm run build` - Build the TypeScript project
+- `npm run dev` - Start development server with hot reload
+- `npm start` - Run the built server
+- `npm test` - Run tests
+- `npm run lint` - Run ESLint
+- `npm run format` - Format code with Prettier
+- `npm run type-check` - Check TypeScript types
+
+## License
+
+MIT

--- a/packages/templates/templates/typescript-advanced/package.json
+++ b/packages/templates/templates/typescript-advanced/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "{{serverName}}",
+  "version": "0.1.0",
+  "description": "{{serverDescription}}",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "{{serverName}}": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src/**/*.ts",
+    "format": "prettier --write src/**/*.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.5.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0",
+    "tsx": "^4.0.0",
+    "vitest": "^1.0.0",
+    "@types/jest": "^29.0.0",
+    "eslint": "^8.0.0",
+    "prettier": "^3.0.0"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "keywords": [
+    "mcp",
+    "model-context-protocol",
+    "context-pods",
+    "{{serverName}}"
+  ]
+}

--- a/packages/templates/templates/typescript-advanced/src/index.ts
+++ b/packages/templates/templates/typescript-advanced/src/index.ts
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+
+/**
+ * {{serverDescription}}
+ *
+ * Advanced TypeScript MCP server with Context-Pods utilities
+ */
+
+import { createServer } from './server.js';
+import { logger } from './utils/logger.js';
+
+/**
+ * Main entry point for the {{serverName}} MCP server
+ */
+async function main(): Promise<void> {
+  try {
+    logger.info('Starting {{serverName}} MCP server...');
+
+    await createServer();
+
+    // Server is now running and connected to stdio
+    logger.info('{{serverName}} MCP server started successfully');
+
+    // Keep the process alive
+    process.stdin.resume();
+  } catch (error) {
+    logger.error('Failed to start {{serverName}} MCP server:', error);
+    process.exit(1);
+  }
+}
+/**
+ * Handle process signals gracefully
+ */
+process.on('SIGINT', () => {
+  logger.info('Received SIGINT, shutting down gracefully...');
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  logger.info('Received SIGTERM, shutting down gracefully...');
+  process.exit(0);
+});
+
+// Start the server
+main().catch((error) => {
+  logger.error('Unhandled error:', error);
+  process.exit(1);
+});

--- a/packages/templates/templates/typescript-advanced/src/resources/index.ts
+++ b/packages/templates/templates/typescript-advanced/src/resources/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Resource registration for {{serverName}}
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '@context-pods/core';
+
+/**
+ * Available resources
+ */
+const resources = [
+  {
+    uri: '{{serverName}}://config',
+    name: 'Server Configuration',
+    description: 'Configuration settings for {{serverName}}',
+    mimeType: 'application/json',
+  },
+  {
+    uri: '{{serverName}}://status',
+    name: 'Server Status',
+    description: 'Current status of {{serverName}}',
+    mimeType: 'application/json',
+  },
+];
+
+/**
+ * Register all resources with the server
+ */
+export async function registerResources(server: Server): Promise<void> {
+  logger.info('Registering resources for {{serverName}}...');
+
+  // List available resources
+  server.setRequestHandler(ListResourcesRequestSchema, async () => {
+    return { resources };
+  });
+
+  // Read resource content
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    const { uri } = request.params;
+
+    if (uri === '{{serverName}}://config') {
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: 'application/json',
+            text: JSON.stringify(
+              {
+                name: '{{serverName}}',
+                version: '0.1.0',
+                description: '{{serverDescription}}',
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    }
+
+    if (uri === '{{serverName}}://status') {
+      return {
+        contents: [
+          {
+            uri,
+            mimeType: 'application/json',
+            text: JSON.stringify(
+              {
+                status: 'running',
+                uptime: process.uptime(),
+                timestamp: new Date().toISOString(),
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    }
+
+    throw new Error(`Unknown resource: ${uri}`);
+  });
+
+  logger.info('All resources registered successfully');
+}

--- a/packages/templates/templates/typescript-advanced/src/server.ts
+++ b/packages/templates/templates/typescript-advanced/src/server.ts
@@ -1,0 +1,39 @@
+/**
+ * MCP Server implementation for {{serverName}}
+ */
+
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { registerTools } from './tools/index.js';
+import { registerResources } from './resources/index.js';
+
+/**
+ * Create and configure the MCP server
+ */
+export async function createServer(): Promise<Server> {
+  const server = new Server(
+    {
+      name: '{{serverName}}',
+      version: '0.1.0',
+    },
+    {
+      capabilities: {
+        tools: {},
+        resources: {},
+        prompts: {},
+      },
+    },
+  );
+
+  // Register tools
+  await registerTools(server);
+
+  // Register resources
+  await registerResources(server);
+
+  // Connect to stdio transport
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+
+  return server;
+}

--- a/packages/templates/templates/typescript-advanced/src/tools/data-tools.ts
+++ b/packages/templates/templates/typescript-advanced/src/tools/data-tools.ts
@@ -1,0 +1,75 @@
+/**
+ * Data processing tools for {{serverName}}
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { logger } from '@context-pods/core';
+import { z } from 'zod';
+
+/**
+ * Schema for data processing tool arguments
+ */
+const DataProcessArgsSchema = z.object({
+  data: z.string().min(1, 'Data is required'),
+  format: z.enum(['json', 'csv', 'xml']).optional(),
+});
+
+/**
+ * Data tools available in this server
+ */
+export const dataTools = [
+  {
+    name: 'process-data',
+    description: 'Process and transform data',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        data: {
+          type: 'string',
+          description: 'Data to process',
+        },
+        format: {
+          type: 'string',
+          enum: ['json', 'csv', 'xml'],
+          description: 'Data format',
+        },
+      },
+      required: ['data'],
+    },
+  },
+];
+
+/**
+ * Handle data tool calls
+ */
+export async function handleDataToolCall(name: string, args: unknown) {
+  if (name === 'process-data') {
+    const { data, format } = DataProcessArgsSchema.parse(args);
+
+    try {
+      // This is a template - actual implementation would process the data
+      const result = `Processed ${format || 'unknown'} data: ${data.substring(0, 100)}...`;
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: result,
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error('Error processing data:', error);
+      throw new Error('Failed to process data');
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Register data-related tools
+ */
+export async function registerDataTools(server: Server): Promise<void> {
+  logger.info('Registering data tools...');
+}

--- a/packages/templates/templates/typescript-advanced/src/tools/file-tools.ts
+++ b/packages/templates/templates/typescript-advanced/src/tools/file-tools.ts
@@ -1,0 +1,70 @@
+/**
+ * File-related tools for {{serverName}}
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '@context-pods/core';
+import { z } from 'zod';
+
+/**
+ * Schema for file read tool arguments
+ */
+const FileReadArgsSchema = z.object({
+  path: z.string().min(1, 'File path is required'),
+});
+
+/**
+ * File tools available in this server
+ */
+export const fileTools = [
+  {
+    name: 'read-file',
+    description: 'Read the contents of a file',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        path: {
+          type: 'string',
+          description: 'Path to the file to read',
+        },
+      },
+      required: ['path'],
+    },
+  },
+];
+
+/**
+ * Handle file tool calls
+ */
+export async function handleFileToolCall(name: string, args: unknown) {
+  if (name === 'read-file') {
+    const { path } = FileReadArgsSchema.parse(args);
+
+    try {
+      // This is a template - actual implementation would read the file
+      const content = `File content from ${path}`;
+
+      return {
+        content: [
+          {
+            type: 'text',
+            text: content,
+          },
+        ],
+      };
+    } catch (error) {
+      logger.error('Error reading file:', error);
+      throw new Error(`Failed to read file: ${path}`);
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Register file-related tools
+ */
+export async function registerFileTools(server: Server): Promise<void> {
+  logger.info('Registering file tools...');
+}

--- a/packages/templates/templates/typescript-advanced/src/tools/index.ts
+++ b/packages/templates/templates/typescript-advanced/src/tools/index.ts
@@ -1,0 +1,44 @@
+/**
+ * Tool registration for {{serverName}}
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { CallToolRequestSchema, ListToolsRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import { logger } from '@context-pods/core';
+import { fileTools, handleFileToolCall } from './file-tools.js';
+import { dataTools, handleDataToolCall } from './data-tools.js';
+import { utilityTools, handleUtilityToolCall } from './utility-tools.js';
+
+/**
+ * Register all tools with the server
+ */
+export async function registerTools(server: Server): Promise<void> {
+  logger.info('Registering tools for {{serverName}}...');
+
+  // Combine all tools
+  const allTools = [...fileTools, ...dataTools, ...utilityTools];
+
+  // List available tools
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    return { tools: allTools };
+  });
+
+  // Handle tool calls
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+
+    // Try each tool handler
+    let result = await handleFileToolCall(name, args);
+    if (result) return result;
+
+    result = await handleDataToolCall(name, args);
+    if (result) return result;
+
+    result = await handleUtilityToolCall(name, args);
+    if (result) return result;
+
+    throw new Error(`Unknown tool: ${name}`);
+  });
+
+  logger.info('All tools registered successfully');
+}

--- a/packages/templates/templates/typescript-advanced/src/tools/utility-tools.ts
+++ b/packages/templates/templates/typescript-advanced/src/tools/utility-tools.ts
@@ -1,0 +1,61 @@
+/**
+ * Utility tools for {{serverName}}
+ */
+
+import type { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { logger } from '@context-pods/core';
+import { z } from 'zod';
+
+/**
+ * Schema for utility tool arguments
+ */
+const UtilityArgsSchema = z.object({
+  input: z.string().min(1, 'Input is required'),
+});
+
+/**
+ * Utility tools available in this server
+ */
+export const utilityTools = [
+  {
+    name: 'echo',
+    description: 'Echo the input text',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        input: {
+          type: 'string',
+          description: 'Text to echo',
+        },
+      },
+      required: ['input'],
+    },
+  },
+];
+
+/**
+ * Handle utility tool calls
+ */
+export async function handleUtilityToolCall(name: string, args: unknown) {
+  if (name === 'echo') {
+    const { input } = UtilityArgsSchema.parse(args);
+
+    return {
+      content: [
+        {
+          type: 'text',
+          text: `Echo: ${input}`,
+        },
+      ],
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Register utility tools
+ */
+export async function registerUtilityTools(server: Server): Promise<void> {
+  logger.info('Registering utility tools...');
+}

--- a/packages/templates/templates/typescript-advanced/src/utils/helpers.ts
+++ b/packages/templates/templates/typescript-advanced/src/utils/helpers.ts
@@ -1,0 +1,178 @@
+/**
+ * Common helper utilities for MCP servers
+ */
+
+import { promises as fs } from 'fs';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+/**
+ * Get the directory path of the current module (ES module compatible)
+ */
+export function getCurrentDirectory(importMetaUrl: string): string {
+  return dirname(fileURLToPath(importMetaUrl));
+}
+
+/**
+ * Ensure a directory exists, creating it if necessary
+ */
+export async function ensureDirectory(dirPath: string): Promise<void> {
+  try {
+    await fs.mkdir(dirPath, { recursive: true });
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code !== 'EEXIST'
+    ) {
+      throw error;
+    }
+  }
+}
+
+/**
+ * Check if a file exists
+ */
+export async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Read JSON file with proper error handling
+ */
+export async function readJsonFile<T = unknown>(filePath: string): Promise<T> {
+  try {
+    const content = await fs.readFile(filePath, 'utf-8');
+    return JSON.parse(content) as T;
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      throw new Error(`File not found: ${filePath}`);
+    }
+    if (error instanceof SyntaxError) {
+      throw new Error(`Invalid JSON in file: ${filePath}`);
+    }
+    throw error;
+  }
+}
+
+/**
+ * Write JSON file with proper formatting
+ */
+export async function writeJsonFile(filePath: string, data: unknown, indent = 2): Promise<void> {
+  const content = JSON.stringify(data, null, indent);
+  await ensureDirectory(dirname(filePath));
+  await fs.writeFile(filePath, content, 'utf-8');
+}
+
+/**
+ * Retry an async operation with exponential backoff
+ */
+export async function retryWithBackoff<T>(
+  operation: () => Promise<T>,
+  maxRetries = 3,
+  initialDelay = 1000,
+): Promise<T> {
+  let lastError: Error | undefined;
+
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      return await operation();
+    } catch (error) {
+      lastError = error as Error;
+      if (i < maxRetries - 1) {
+        const delay = initialDelay * Math.pow(2, i);
+        await sleep(delay);
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+/**
+ * Sleep for a specified number of milliseconds
+ */
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Debounce a function
+ */
+export function debounce<T extends (...args: never[]) => unknown>(
+  func: T,
+  wait: number,
+): (...args: Parameters<T>) => void {
+  let timeout: NodeJS.Timeout | null = null;
+
+  return (...args: Parameters<T>) => {
+    if (timeout) clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
+}
+
+/**
+ * Create a simple event emitter
+ */
+export class SimpleEventEmitter<T extends Record<string, unknown[]>> {
+  private listeners: Map<keyof T, Array<(...args: T[keyof T]) => void>> = new Map();
+
+  on<K extends keyof T>(event: K, listener: (...args: T[K]) => void): void {
+    const listeners = this.listeners.get(event) || [];
+    listeners.push(listener);
+    this.listeners.set(event, listeners);
+  }
+
+  off<K extends keyof T>(event: K, listener: (...args: T[K]) => void): void {
+    const listeners = this.listeners.get(event) || [];
+    const index = listeners.indexOf(listener);
+    if (index > -1) {
+      listeners.splice(index, 1);
+    }
+  }
+
+  emit<K extends keyof T>(event: K, ...args: T[K]): void {
+    const listeners = this.listeners.get(event) || [];
+    listeners.forEach((listener) => listener(...args));
+  }
+}
+
+/**
+ * Format bytes to human readable string
+ */
+export function formatBytes(bytes: number, decimals = 2): string {
+  if (bytes === 0) return '0 Bytes';
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
+}
+
+/**
+ * Create a timeout promise
+ */
+export function timeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  message = 'Operation timed out',
+): Promise<T> {
+  return Promise.race([
+    promise,
+    sleep(ms).then(() => {
+      throw new Error(message);
+    }),
+  ]);
+}

--- a/packages/templates/templates/typescript-advanced/src/utils/logger.ts
+++ b/packages/templates/templates/typescript-advanced/src/utils/logger.ts
@@ -1,0 +1,69 @@
+/**
+ * Simple logger implementation for standalone MCP servers
+ */
+
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+}
+
+export class Logger {
+  private level: LogLevel;
+  private prefix: string;
+
+  constructor(prefix = '{{serverName}}', level = LogLevel.INFO) {
+    this.prefix = prefix;
+    this.level = this.parseLogLevel(process.env.LOG_LEVEL) || level;
+  }
+
+  private parseLogLevel(level?: string): LogLevel | undefined {
+    if (!level) return undefined;
+    const upperLevel = level.toUpperCase();
+    return LogLevel[upperLevel as keyof typeof LogLevel] as LogLevel | undefined;
+  }
+
+  private log(level: LogLevel, message: string, ...args: unknown[]): void {
+    if (level < this.level) return;
+
+    const timestamp = new Date().toISOString();
+    const levelName = LogLevel[level];
+    const formattedMessage = `[${timestamp}] [${this.prefix}] [${levelName}] ${message}`;
+
+    switch (level) {
+      case LogLevel.ERROR:
+        console.error(formattedMessage, ...args);
+        break;
+      case LogLevel.WARN:
+        console.warn(formattedMessage, ...args);
+        break;
+      default:
+        // eslint-disable-next-line no-console
+        console.log(formattedMessage, ...args);
+    }
+  }
+
+  debug(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.DEBUG, message, ...args);
+  }
+
+  info(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, message, ...args);
+  }
+
+  warn(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.WARN, message, ...args);
+  }
+
+  error(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.ERROR, message, ...args);
+  }
+
+  child(prefix: string): Logger {
+    return new Logger(`${this.prefix}:${prefix}`, this.level);
+  }
+}
+
+// Default logger instance
+export const logger = new Logger();

--- a/packages/templates/templates/typescript-advanced/src/utils/validation.ts
+++ b/packages/templates/templates/typescript-advanced/src/utils/validation.ts
@@ -1,0 +1,130 @@
+/**
+ * Common validation utilities for MCP servers
+ */
+
+import { z } from 'zod';
+
+/**
+ * Common validation schemas
+ */
+export const schemas = {
+  // String validations
+  nonEmptyString: z.string().min(1, 'String cannot be empty'),
+
+  // Number validations
+  positiveNumber: z.number().positive('Number must be positive'),
+  port: z.number().int().min(1).max(65535),
+
+  // File path validations
+  filePath: z.string().regex(/^[a-zA-Z0-9\-_./\\]+$/, 'Invalid file path'),
+
+  // URL validations
+  url: z.string().url('Invalid URL format'),
+
+  // Common patterns
+  identifier: z.string().regex(/^[a-zA-Z][a-zA-Z0-9_-]*$/, 'Invalid identifier format'),
+  semver: z.string().regex(/^\d+\.\d+\.\d+$/, 'Invalid semantic version format'),
+};
+
+/**
+ * Validate data against a schema and return formatted errors
+ */
+export function validate<T>(
+  schema: z.ZodSchema<T>,
+  data: unknown,
+): { success: true; data: T } | { success: false; errors: string[] } {
+  try {
+    const validated = schema.parse(data);
+    return { success: true, data: validated };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      const errors = error.errors.map((err) => `${err.path.join('.')}: ${err.message}`);
+      return { success: false, errors };
+    }
+    return { success: false, errors: ['Unknown validation error'] };
+  }
+}
+
+/**
+ * Create a validated environment variable getter
+ */
+export function createEnvValidator<T extends Record<string, z.ZodSchema>>(
+  schema: T,
+): { [K in keyof T]: z.infer<T[K]> } {
+  const result = {} as { [K in keyof T]: z.infer<T[K]> };
+
+  for (const [key, validator] of Object.entries(schema)) {
+    const value = process.env[key];
+    const validated = validator.safeParse(value);
+
+    if (!validated.success) {
+      throw new Error(`Invalid environment variable ${key}: ${validated.error.errors[0].message}`);
+    }
+
+    result[key as keyof T] = validated.data as z.infer<T[keyof T]>;
+  }
+
+  return result;
+}
+
+/**
+ * Common parameter validators for MCP tools
+ */
+export const parameterValidators = {
+  /**
+   * Validate required string parameter
+   */
+  requiredString: (value: unknown, name: string): string => {
+    const result = schemas.nonEmptyString.safeParse(value);
+    if (!result.success) {
+      throw new Error(`Parameter '${name}' is required and must be a non-empty string`);
+    }
+    return result.data;
+  },
+
+  /**
+   * Validate optional string parameter
+   */
+  optionalString: (value: unknown, name: string): string | undefined => {
+    if (value === undefined || value === null) return undefined;
+    const result = z.string().safeParse(value);
+    if (!result.success) {
+      throw new Error(`Parameter '${name}' must be a string if provided`);
+    }
+    return result.data;
+  },
+
+  /**
+   * Validate boolean parameter
+   */
+  boolean: (value: unknown, name: string): boolean => {
+    const result = z.boolean().safeParse(value);
+    if (!result.success) {
+      throw new Error(`Parameter '${name}' must be a boolean`);
+    }
+    return result.data;
+  },
+
+  /**
+   * Validate number parameter
+   */
+  number: (value: unknown, name: string): number => {
+    const result = z.number().safeParse(value);
+    if (!result.success) {
+      throw new Error(`Parameter '${name}' must be a number`);
+    }
+    return result.data;
+  },
+
+  /**
+   * Validate array parameter
+   */
+  array: <T>(value: unknown, name: string, itemValidator?: z.ZodSchema<T>): T[] => {
+    const schema = itemValidator ? z.array(itemValidator) : z.array(z.unknown());
+    const result = schema.safeParse(value);
+    if (!result.success) {
+      throw new Error(`Parameter '${name}' must be an array`);
+    }
+    return result.data as T[];
+  },
+};

--- a/packages/templates/templates/typescript-advanced/template.json
+++ b/packages/templates/templates/typescript-advanced/template.json
@@ -1,0 +1,133 @@
+{
+  "name": "typescript-advanced",
+  "description": "Advanced TypeScript MCP server with full TurboRepo optimization and Context-Pods utilities",
+  "version": "1.0.0",
+  "author": "Context-Pods Team",
+  "tags": ["advanced", "typescript", "turbo", "utilities"],
+  "language": "typescript",
+  "optimization": {
+    "turboRepo": true,
+    "hotReload": true,
+    "sharedDependencies": true,
+    "buildCaching": true
+  },
+  "variables": {
+    "serverName": {
+      "description": "Name of the MCP server",
+      "type": "string",
+      "required": true,
+      "validation": {
+        "pattern": "^[a-z0-9-]+$"
+      }
+    },
+    "serverDescription": {
+      "description": "Description of the MCP server",
+      "type": "string",
+      "required": true
+    },
+    "includeLogging": {
+      "description": "Include structured logging with Context-Pods logger",
+      "type": "boolean",
+      "required": false,
+      "default": true
+    },
+    "includeErrorHandling": {
+      "description": "Include advanced error handling with Context-Pods errors",
+      "type": "boolean",
+      "required": false,
+      "default": true
+    },
+    "includeValidation": {
+      "description": "Include Zod schema validation",
+      "type": "boolean",
+      "required": false,
+      "default": true
+    },
+    "toolCategories": {
+      "description": "Categories of tools to include",
+      "type": "array",
+      "required": false,
+      "default": ["file", "data", "utility"],
+      "validation": {
+        "options": ["file", "data", "utility", "network", "system"]
+      }
+    }
+  },
+  "files": [
+    {
+      "path": "package.json",
+      "template": true
+    },
+    {
+      "path": "tsconfig.json",
+      "template": false
+    },
+    {
+      "path": "src/index.ts",
+      "template": true
+    },
+    {
+      "path": "src/server.ts",
+      "template": true
+    },
+    {
+      "path": "src/tools/index.ts",
+      "template": true
+    },
+    {
+      "path": "src/tools/file-tools.ts",
+      "template": true
+    },
+    {
+      "path": "src/tools/data-tools.ts",
+      "template": true
+    },
+    {
+      "path": "src/tools/utility-tools.ts",
+      "template": true
+    },
+    {
+      "path": "src/resources/index.ts",
+      "template": true
+    },
+    {
+      "path": "src/utils/validation.ts",
+      "template": true
+    },
+    {
+      "path": "src/utils/helpers.ts",
+      "template": true
+    },
+    {
+      "path": "README.md",
+      "template": true
+    },
+    {
+      "path": ".env.example",
+      "template": false
+    }
+  ],
+  "dependencies": {
+    "core": ["@context-pods/core"],
+    "dev": ["@types/node", "typescript", "tsx", "vitest", "@types/jest"],
+    "peer": ["@modelcontextprotocol/sdk", "zod"]
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsx watch src/index.ts",
+    "start": "node dist/index.js",
+    "test": "vitest",
+    "test:watch": "vitest --watch",
+    "type-check": "tsc --noEmit",
+    "lint": "eslint src/**/*.ts",
+    "format": "prettier --write src/**/*.ts"
+  },
+  "mcpConfig": {
+    "defaultCommand": "node",
+    "defaultArgs": ["dist/index.js"],
+    "defaultEnv": {
+      "NODE_ENV": "production"
+    },
+    "generateByDefault": true
+  }
+}

--- a/packages/templates/templates/typescript-advanced/tsconfig.json
+++ b/packages/templates/templates/typescript-advanced/tsconfig.json
@@ -1,0 +1,37 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "moduleResolution": "Node16",
+    "allowSyntheticDefaultImports": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "allowJs": false,
+    "noEmit": false,
+    "incremental": true,
+    "composite": false,
+    "isolatedModules": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "allowUnreachableCode": false,
+    "allowUnusedLabels": false
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
+  "ts-node": {
+    "esm": true,
+    "experimentalSpecifierResolution": "node"
+  }
+}

--- a/packages/templates/tsconfig.json
+++ b/packages/templates/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/testing",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Comprehensive testing and validation framework for Context-Pods MCP servers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Created new `@context-pods/templates` package to bundle all templates
- Updated CLI and core packages to use templates as a dependency
- Modified path resolution to load templates from the installed package

## Motivation
The globally installed CLI was unable to find templates because they weren't bundled with the npm installation. Users had to set environment variables or have templates locally available, which created a poor developer experience.

## Changes
- **New Package**: `@context-pods/templates` - Contains all template files and provides APIs for template discovery
- **Path Resolution**: Updated to check for templates in the installed npm package first
- **Dependencies**: Added `@context-pods/templates` as a dependency to CLI, core, and server packages
- **Build Process**: Templates are copied during the build process of the templates package
- **Version Sync**: Updated all packages to version 0.1.5

## Benefits
- ✅ Templates are bundled with npm installations
- ✅ No need for environment variables or local template directories
- ✅ Better developer experience for global CLI users
- ✅ Templates can be versioned and distributed independently
- ✅ Other tools can potentially reuse the templates package

## Test plan
- [x] Build all packages successfully
- [x] Local CLI can find and use templates
- [ ] Global npm installation works without environment variables
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)