### PR TITLE
fix: add missing packages to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,12 @@ jobs:
           echo "Publishing @context-pods/cli..."
           npm publish --workspace=@context-pods/cli --access public
 
+          echo "Publishing @context-pods/create..."
+          npm publish --workspace=@context-pods/create --access public
+
+          echo "Publishing @context-pods/templates..."
+          npm publish --workspace=@context-pods/templates --access public
+
       - name: Update release notes
         uses: actions/github-script@v7
         with:
@@ -92,7 +98,9 @@ jobs:
               '@context-pods/core',
               '@context-pods/testing', 
               '@context-pods/server',
-              '@context-pods/cli'
+              '@context-pods/cli',
+              '@context-pods/create',
+              '@context-pods/templates'
             ];
 
             const publishedInfo = `\n\n## Published Packages (v${version})\n\n` +

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "context-pods",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "context-pods",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "workspaces": [
         "packages/*"
@@ -7506,11 +7506,11 @@
     },
     "packages/cli": {
       "name": "@context-pods/cli",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
-        "@context-pods/core": "^0.1.4",
-        "@context-pods/templates": "^0.1.4",
+        "@context-pods/core": "^0.1.6",
+        "@context-pods/templates": "^0.1.6",
         "chalk": "^5.3.0",
         "chokidar": "^3.6.0",
         "commander": "^11.1.0",
@@ -7639,10 +7639,10 @@
     },
     "packages/core": {
       "name": "@context-pods/core",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
-        "@context-pods/templates": "^0.1.4",
+        "@context-pods/templates": "^0.1.6",
         "zod": "^3.23.0"
       },
       "devDependencies": {
@@ -7651,7 +7651,7 @@
     },
     "packages/create": {
       "name": "@context-pods/create",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "bin": {
         "create-context-pods": "bin/create-context-pods.js"
@@ -7662,10 +7662,10 @@
     },
     "packages/server": {
       "name": "@context-pods/server",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "dependencies": {
-        "@context-pods/core": "^0.1.4",
-        "@context-pods/templates": "^0.1.4",
+        "@context-pods/core": "^0.1.6",
+        "@context-pods/templates": "^0.1.6",
         "@modelcontextprotocol/sdk": "^1.0.0",
         "sqlite3": "^5.1.6"
       },
@@ -7682,7 +7682,7 @@
     },
     "packages/templates": {
       "name": "@context-pods/templates",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "zod": "^3.23.0"
@@ -7694,7 +7694,7 @@
     },
     "packages/testing": {
       "name": "@context-pods/testing",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "@context-pods/core": "*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-pods",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "ContextPods - a developer tool that generates functional MCP servers from templates",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/cli",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "TurboRepo-optimized CLI for Context-Pods MCP development suite",
   "type": "module",
   "main": "./dist/cli.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/core",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Core utilities and types for Context-Pods MCP farm",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/create",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "npx runner for Context-Pods MCP development suite",
   "type": "module",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/server",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Core MCP server for Context-Pods toolkit",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/templates",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Template collection for Context-Pods MCP server generation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/testing",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Comprehensive testing and validation framework for Context-Pods MCP servers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary
- Added @context-pods/create and @context-pods/templates to the GitHub release workflow
- Both packages are now included in the npm publishing step and release notes

## Test plan
- [ ] GitHub Actions workflow passes validation
- [ ] Release action publishes all 6 packages when triggered
- [ ] Release notes include all packages with correct npm links

🤖 Generated with [Claude Code](https://claude.ai/code)