### PR TITLE
fix: add templates package to npx installer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context-pods",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "ContextPods - a developer tool that generates functional MCP servers from templates",
   "private": true,
   "workspaces": [

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/cli",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "TurboRepo-optimized CLI for Context-Pods MCP development suite",
   "type": "module",
   "main": "./dist/cli.js",
@@ -38,8 +38,8 @@
   "author": "Conor Luddy",
   "license": "MIT",
   "dependencies": {
-    "@context-pods/core": "^0.1.6",
-    "@context-pods/templates": "^0.1.6",
+    "@context-pods/core": "^0.1.8",
+    "@context-pods/templates": "^0.1.8",
     "commander": "^11.1.0",
     "chalk": "^5.3.0",
     "fs-extra": "^11.2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/core",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Core utilities and types for Context-Pods MCP farm",
   "type": "module",
   "main": "./dist/index.js",
@@ -32,7 +32,7 @@
   "license": "MIT",
   "dependencies": {
     "zod": "^3.23.0",
-    "@context-pods/templates": "^0.1.6"
+    "@context-pods/templates": "^0.1.8"
   },
   "devDependencies": {
     "@types/node": "^20.14.0"

--- a/packages/create/bin/create-context-pods.js
+++ b/packages/create/bin/create-context-pods.js
@@ -13,9 +13,12 @@ const tempDir = mkdtempSync(join(tmpdir(), 'context-pods-'));
 try {
   // Install the CLI and core packages in the temp directory
   console.log('📦 Installing Context-Pods CLI...');
-  execSync(`npm install --prefix "${tempDir}" @context-pods/cli@latest @context-pods/core@latest`, {
-    stdio: 'inherit',
-  });
+  execSync(
+    `npm install --prefix "${tempDir}" @context-pods/cli@latest @context-pods/core@latest @context-pods/templates@latest`,
+    {
+      stdio: 'inherit',
+    },
+  );
 
   // Get the CLI path
   const cliPath = join(tempDir, 'node_modules', '@context-pods', 'cli', 'bin', 'context-pods');

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/create",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "npx runner for Context-Pods MCP development suite",
   "type": "module",
   "bin": {

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/server",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Core MCP server for Context-Pods toolkit",
   "type": "module",
   "main": "dist/index.js",
@@ -19,8 +19,8 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.0",
-    "@context-pods/core": "^0.1.6",
-    "@context-pods/templates": "^0.1.6",
+    "@context-pods/core": "^0.1.8",
+    "@context-pods/templates": "^0.1.8",
     "sqlite3": "^5.1.6"
   },
   "devDependencies": {

--- a/packages/templates/package.json
+++ b/packages/templates/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/templates",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Template collection for Context-Pods MCP server generation",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@context-pods/testing",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "Comprehensive testing and validation framework for Context-Pods MCP servers",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
- Update create-context-pods.js to install @context-pods/templates
- Bump all packages to v0.1.8
- This fixes 'templates directory not found' error when using npx