### PR TITLE
fix: resolve templates path correctly when running via npx

### DIFF
--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -8,6 +8,7 @@ import { output } from './utils/output-formatter.js';
 // import { TurboIntegration } from './utils/turbo-integration.js'; // Unused for now
 import { CacheManager } from './utils/cache-manager.js';
 import { getAllExistingTemplatePaths } from '@context-pods/core';
+import { getTemplatesPath } from '@context-pods/templates';
 import type { CommandContext } from './types/cli-types.js';
 
 // Import command handlers (these will be implemented next)
@@ -286,9 +287,13 @@ async function createCommandContext(command: Command): Promise<CommandContext> {
   const workingDir = process.cwd();
 
   // Use consolidated path resolution from core package
+  // First, try to get templates from the installed package
+  const installedTemplatesPath = getTemplatesPath();
+
   const templatePaths = getAllExistingTemplatePaths({
     envVar: 'CONTEXT_PODS_TEMPLATES_PATH',
     additionalPaths: [
+      installedTemplatesPath, // Add the installed templates path first
       global.templatesPath.startsWith('/')
         ? global.templatesPath
         : `${workingDir}/${global.templatesPath}`,

--- a/packages/cli/src/commands/generate.ts
+++ b/packages/cli/src/commands/generate.ts
@@ -7,6 +7,7 @@ import path from 'path';
 import inquirer from 'inquirer';
 import type { TemplateSelectionResult, TemplateVariable } from '@context-pods/core';
 import { TemplateSelector, DefaultTemplateEngine } from '@context-pods/core';
+import { getTemplatesPath } from '@context-pods/templates';
 import type { GenerateOptions, CommandContext, CommandResult } from '../types/cli-types.js';
 import { output } from '../utils/output-formatter.js';
 
@@ -95,7 +96,9 @@ async function selectTemplate(
   templateName: string | undefined,
   context: CommandContext,
 ): Promise<TemplateSelectionResult> {
-  const templateSelector = new TemplateSelector(context.templatePaths[0] || './templates');
+  // Use the templates path from the @context-pods/templates package
+  const templatesPath = context.templatePaths[0] || getTemplatesPath();
+  const templateSelector = new TemplateSelector(templatesPath);
 
   if (templateName) {
     // User specified template - find it in available templates

--- a/packages/create/bin/create-context-pods.js
+++ b/packages/create/bin/create-context-pods.js
@@ -29,10 +29,17 @@ try {
     .map((arg) => `"${arg}"`)
     .join(' ');
 
-  // Run the CLI with the forwarded arguments
+  // Set the templates path environment variable to the installed templates
+  const templatesPath = join(tempDir, 'node_modules', '@context-pods', 'templates', 'templates');
+
+  // Run the CLI with the forwarded arguments and proper environment
   execSync(`node "${cliPath}" ${args}`, {
     stdio: 'inherit',
     cwd: process.cwd(),
+    env: {
+      ...process.env,
+      CONTEXT_PODS_TEMPLATES_PATH: templatesPath,
+    },
   });
 } catch (error) {
   console.error('\n❌ Error running Context-Pods:', error.message);


### PR DESCRIPTION
## Summary
- Fixed templates directory not found error when running `npx @context-pods/create generate`
- Templates are now correctly resolved from the installed package location
- Works both locally and via npx

## Problem
When running `npx @context-pods/create generate`, the command would fail with:
```
Failed to scan templates directory: ./templates Error: ENOENT: no such file or directory
```

This happened because the CLI was looking for templates relative to the current working directory instead of the installed package location.

## Solution
1. Set `CONTEXT_PODS_TEMPLATES_PATH` environment variable in the npx runner to point to the installed templates
2. Import and use `getTemplatesPath()` from `@context-pods/templates` package in the CLI
3. Add the installed templates path to the list of paths checked by the CLI

## Test plan
[x] Tested `npx @context-pods/create generate` successfully shows template selection
[x] All existing tests pass
[x] Build completes successfully

🤖 Generated with [Claude Code](https://claude.ai/code)